### PR TITLE
fix: remove ref to Thread from classes to ensure Net461 compatibility

### DIFF
--- a/src/Yaapii.Atoms/Func/FuncWithFallback.cs
+++ b/src/Yaapii.Atoms/Func/FuncWithFallback.cs
@@ -112,11 +112,11 @@ namespace Yaapii.Atoms.Func
             {
                 result = this._func.Invoke(input);
             }
-            catch (System.Threading.ThreadStateException ex)
-            {
-                Thread.CurrentThread.Join();
-                result = this._fallback.Invoke(ex);
-            }
+            //catch (System.Threading.ThreadStateException ex)
+            //{
+            //    Thread.CurrentThread.Join();
+            //    result = this._fallback.Invoke(ex);
+            //}
             catch (Exception ex)
             {
                 result = this._fallback.Invoke(ex);

--- a/src/Yaapii.Atoms/Func/IoCheckedBiFunc.cs
+++ b/src/Yaapii.Atoms/Func/IoCheckedBiFunc.cs
@@ -71,11 +71,11 @@ namespace Yaapii.Atoms.Func
             {
                 throw ex;
             }
-            catch (System.Threading.ThreadStateException ex)
-            {
-                Thread.CurrentThread.Join();
-                throw new IOException(ex.Message, ex);
-            }
+            //catch (System.Threading.ThreadStateException ex)
+            //{
+            //    Thread.CurrentThread.Join();
+            //    throw new IOException(ex.Message, ex);
+            //}
             catch (Exception ex)
             {
                 throw new IOException(ex.Message, ex);

--- a/src/Yaapii.Atoms/Func/IoCheckedFunc.cs
+++ b/src/Yaapii.Atoms/Func/IoCheckedFunc.cs
@@ -67,11 +67,11 @@ namespace Yaapii.Atoms.Func
             {
                 throw ex;
             }
-            catch (System.Threading.ThreadStateException ex)
-            {
-                Thread.CurrentThread.Join();
-                throw new IOException(ex.Message, ex);
-            }
+            //catch (System.Threading.ThreadStateException ex)
+            //{
+            //    Thread.CurrentThread.Join();
+            //    throw new IOException(ex.Message, ex);
+            //}
             catch (Exception ex)
             {
                 throw new IOException(ex.Message, ex);

--- a/src/Yaapii.Atoms/Func/RetryFunc.cs
+++ b/src/Yaapii.Atoms/Func/RetryFunc.cs
@@ -123,12 +123,12 @@ namespace Yaapii.Atoms.Func
                 {
                     return this._func.Invoke(input);
                 }
-                catch (System.Threading.ThreadStateException ex)
-                {
-                    Thread.CurrentThread.Join();
-                    error = ex;
-                    break;
-                }
+                //catch (System.Threading.ThreadStateException ex)
+                //{
+                //    Thread.CurrentThread.Join();
+                //    error = ex;
+                //    break;
+                //}
                 catch (Exception ex)
                 {
                     error = ex;

--- a/src/Yaapii.Atoms/Yaapii.Atoms.csproj
+++ b/src/Yaapii.Atoms/Yaapii.Atoms.csproj
@@ -16,8 +16,4 @@
     <DocumentationFile>bin\Debug\netstandard1.4\.xml</DocumentationFile>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [X] I made sure that my code builds
- [X] I merged the master into this branch before pushing
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
Reference to System.Threading.Thread nuget causes Net461 to fail using some classes

### What is the new behavior?
Reference to System.Threading.Thread removed.

### Does this PR introduce a breaking change? (check one with "x")
- [ ] Yes
- [X] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications

###  Other information