### PR TITLE
Change namespace from 'Yaapii.Atoms.Scalar' to 'Yaapii.Atoms.Text'

### DIFF
--- a/src/Yaapii.Atoms/Primitives/BoolOf.cs
+++ b/src/Yaapii.Atoms/Primitives/BoolOf.cs
@@ -26,7 +26,7 @@ using System.IO;
 using System.Text;
 using Yaapii.Atoms.Text;
 
-namespace Yaapii.Atoms.Scalar
+namespace Yaapii.Atoms.Text
 {
     /// <summary>
     /// A bool out of text objects.

--- a/src/Yaapii.Atoms/Primitives/DoubleOf.cs
+++ b/src/Yaapii.Atoms/Primitives/DoubleOf.cs
@@ -24,9 +24,10 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using Yaapii.Atoms.Scalar;
 using Yaapii.Atoms.Text;
 
-namespace Yaapii.Atoms.Scalar
+namespace Yaapii.Atoms.Text
 {
     /// <summary>
     /// A double out of text.

--- a/src/Yaapii.Atoms/Primitives/LongOf.cs
+++ b/src/Yaapii.Atoms/Primitives/LongOf.cs
@@ -27,7 +27,7 @@ using System.Text;
 using Yaapii.Atoms.Scalar;
 using Yaapii.Atoms.Text;
 
-namespace Yaapii.Atoms.Scalar
+namespace Yaapii.Atoms.Text
 {
     /// <summary>
     /// Text as long

--- a/tests/Yaapii.Atoms.Tests/Scalar/LongOfTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Scalar/LongOfTest.cs
@@ -25,6 +25,7 @@ using System.Collections.Generic;
 using System.Text;
 using Xunit;
 using Yaapii.Atoms.Scalar;
+using Yaapii.Atoms.Text;
 
 namespace Yaapii.Atoms.Tests.Scalar
 {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
<!-- Descripe the current behavior or link to a open issue -->
Wrong namespace used #25

### What is the new behavior?
<!-- Descripe the new behavior -->
Right namespace used.

### Does this PR introduce a breaking change? (check one with "x")
- [x] Yes
- [ ] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications
Use new right namespace.
'Yaapii.Atoms.Text' instead of 'Yaapii.Atoms.Scalar' for 
- DoubleOf
- LongOf
- BoolOf

###  Other information
Found a broken test #32 