### PR TITLE
Fix i156 base64decodedtext remove bom

### DIFF
--- a/src/Yaapii.Atoms/Text/Base64DecodedText.cs
+++ b/src/Yaapii.Atoms/Text/Base64DecodedText.cs
@@ -21,8 +21,8 @@
 // SOFTWARE.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
+using Yaapii.Atoms.Bytes;
+using Yaapii.Atoms.IO;
 
 namespace Yaapii.Atoms.Text
 {
@@ -46,7 +46,12 @@ namespace Yaapii.Atoms.Text
         /// <param name="text">text to decode</param>
         public Base64DecodedText(IText text)
         {
-            this._origin = text;
+            this._origin =
+                new TextOf(
+                    new Base64Bytes(
+                        new BytesOf(text)
+                    )
+                );
         }
 
         /// <summary>
@@ -55,8 +60,7 @@ namespace Yaapii.Atoms.Text
         /// <returns>the content as a string</returns>
         public String AsString()
         {
-            return new TextOf(
-                Convert.FromBase64String(this._origin.AsString())).AsString();
+            return this._origin.AsString();
         }
 
         /// <summary>
@@ -66,7 +70,7 @@ namespace Yaapii.Atoms.Text
         /// <returns>true if equal.</returns>
         public bool Equals(IText text)
         {
-            return this.Equals(text);
+            return _origin.Equals(text);
         }
     }
 }

--- a/src/Yaapii.Atoms/Text/TextOf.cs
+++ b/src/Yaapii.Atoms/Text/TextOf.cs
@@ -21,15 +21,11 @@
 // SOFTWARE.
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text;
-using Yaapii.Atoms.Func;
 using Yaapii.Atoms.IO;
-using Yaapii.Atoms.Misc;
 using Yaapii.Atoms.Scalar;
-using Yaapii.Atoms.Text;
 
 #pragma warning disable MaxClassLength // Class length max
 namespace Yaapii.Atoms.Text
@@ -238,7 +234,7 @@ namespace Yaapii.Atoms.Text
             () => 
             {
                 var memoryStream = new MemoryStream(bytes.AsBytes());
-                return new StreamReader(memoryStream).ReadToEnd();
+                return new StreamReader(memoryStream).ReadToEnd(); // removes the BOM from the Byte-Array
             })
         { }
 

--- a/tests/Yaapii.Atoms.Tests/Text/Base64DecodedTextTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/Base64DecodedTextTest.cs
@@ -1,0 +1,73 @@
+﻿// MIT License
+//
+// Copyright(c) 2017 ICARUS Consulting GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
+using Yaapii.Atoms.Bytes;
+using Yaapii.Atoms.IO;
+using Yaapii.Atoms.Text;
+
+namespace Yaapii.Atoms.Tests.Text
+{
+    public sealed class Base64DecodedTextTest
+    {
+        [Theory]
+        [InlineData("A fancy text")]
+        [InlineData("A fancy text with \n line break")]
+        [InlineData("A fancy text with € special character")]
+        public void DecodeFromFile(string text)
+        {
+            var file = Path.Combine(Directory.GetCurrentDirectory(), "test.txt");
+            try
+            {
+                new LengthOf(
+                    new TeeInput(
+                        new TextOf(
+                            new BytesBase64(
+                                new BytesOf(
+                                    new TextOf(text)
+                                )
+                            )
+                        ).AsString(),
+                        new OutputTo(new Uri(file))
+                    )
+                ).Value();
+
+                Assert.True(
+                    new Base64DecodedText(
+                        new TextOf(
+                            new Uri(file)
+                        )
+                    ).Equals(
+                    new TextOf(text)));
+            }
+            finally
+            {
+                // Cleanup
+                if (File.Exists(file)) File.Delete(file);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
<!-- Descripe the current behavior or link to a open issue -->
#156 

Base64DecodedText.Equals has a recursion call to it self.

### What is the new behavior?
<!-- Descripe the new behavior -->
BOM is ignored on decoding bytes as base64 to text.
Fix the recursive call to Base64DecodedText.Equals

### Does this PR introduce a breaking change? (check one with "x")
- [ ] Yes
- [x] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications

###  Other information