### PR TITLE
Change namespace Yaapii.IO to Yaapii.Atoms.IO

### DIFF
--- a/src/Yaapii.Atoms/IO/ResourceNotFoundException.cs
+++ b/src/Yaapii.Atoms/IO/ResourceNotFoundException.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
 using Yaapii.Atoms.Text;
 
-namespace Yaapii.IO.Error
+namespace Yaapii.Atoms.IO.Error
 {
     /// <summary>
     /// When a resource cannot be found.

--- a/src/Yaapii.Atoms/IO/ResourceOf.cs
+++ b/src/Yaapii.Atoms/IO/ResourceOf.cs
@@ -1,14 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
-using System.Text;
-using Yaapii.Atoms;
-using Yaapii.Atoms.Error;
+using Yaapii.Atoms.IO.Error;
 using Yaapii.Atoms.Scalar;
-using Yaapii.IO.Error;
 
-namespace Yaapii.IO
+namespace Yaapii.Atoms.IO
 {
     /// <summary>
     /// <para>A embedded resource.</para>

--- a/tests/Yaapii.Atoms.Tests/IO/ResourceOfTest.cs
+++ b/tests/Yaapii.Atoms.Tests/IO/ResourceOfTest.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Reflection;
-using System.Text;
+﻿using System.Reflection;
 using Xunit;
+using Yaapii.Atoms.IO;
 using Yaapii.Atoms.Text;
-using Yaapii.IO;
 
 namespace Yaapii.Atoms.Tests.IO
 {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
#162

### What is the new behavior?
`ResourceOf` and `ResourceNotFoundException` are now located in the namespace `Yaapii.Atom.IO`

### Does this PR introduce a breaking change? (check one with "x")
- [x] Yes
- [ ] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications
The namespace `Yaapii.IO` changed to `Yaapii.Atoms.IO`

###  Other information
closes #162 