### PR TITLE
New Text decorators: StartsWith() and EndsWith()

### DIFF
--- a/src/Yaapii.Atoms/Text/EndsWith.cs
+++ b/src/Yaapii.Atoms/Text/EndsWith.cs
@@ -1,0 +1,67 @@
+﻿// MIT License
+//
+// Copyright(c) 2017 ICARUS Consulting GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Text.RegularExpressions;
+
+namespace Yaapii.Atoms.Text
+{
+    /// <summary>
+    /// Checks if a text ends with an given content.
+    /// </summary>
+    public sealed class EndsWith : IScalar<bool>
+    {
+        private readonly IText _text;
+        private readonly IText _tail;
+
+        /// <summary>
+        /// Checks if a <see cref="IText"/> ends with an given <see cref="string"/>
+        /// </summary>
+        /// <param name="text">Text to test</param>
+        /// <param name="tail">Ending content to use in the test</param>
+        public EndsWith(IText text, string tail) : this(
+            text,
+            new TextOf(tail)
+        )
+        { }
+
+        /// <summary>
+        /// Checks if a <see cref="IText"/> ends with an given <see cref="IText"/>
+        /// </summary>
+        /// <param name="text">Text to test</param>
+        /// <param name="tail">Ending content to use in the test</param>
+        public EndsWith(IText text, IText tail)
+        {
+            this._text = text;
+            this._tail = tail;
+        }
+
+        /// <summary>
+        /// Gets the result
+        /// </summary>
+        /// <returns>The result</returns>
+        public bool Value()
+        {
+            var regex = new Regex(Regex.Escape(this._tail.AsString()) + "$");
+            return regex.IsMatch(this._text.AsString());
+        }
+    }
+}

--- a/src/Yaapii.Atoms/Text/StartsWith.cs
+++ b/src/Yaapii.Atoms/Text/StartsWith.cs
@@ -1,0 +1,45 @@
+﻿using System.Text.RegularExpressions;
+
+namespace Yaapii.Atoms.Text
+{
+    /// <summary>
+    /// Checks if a text starts with an given content.
+    /// </summary>
+    public sealed class StartsWith : IScalar<bool>
+    {
+        private readonly IText _text;
+        private readonly IText _start;
+
+        /// <summary>
+        /// Checks if a <see cref="IText"/> ends with an given <see cref="string"/>
+        /// </summary>
+        /// <param name="text">Text to test</param>
+        /// <param name="start">Starting content to use in the test</param>
+        public StartsWith(IText text, string start) : this(
+            text,
+            new TextOf(start)
+        )
+        { }
+
+        /// <summary>
+        /// Checks if a <see cref="IText"/> ends with an given <see cref="IText"/>
+        /// </summary>
+        /// <param name="text">Text to test</param>
+        /// <param name="start">Starting content to use in the test</param>
+        public StartsWith(IText text, IText start)
+        {
+            this._text = text;
+            this._start = start;
+        }
+
+        /// <summary>
+        /// Gets the result
+        /// </summary>
+        /// <returns>The result</returns>
+        public bool Value()
+        {
+            var regex = new Regex("^" + Regex.Escape(this._start.AsString()));
+            return regex.IsMatch(this._text.AsString());
+        }
+    }
+}

--- a/src/Yaapii.Atoms/Text/SubText.cs
+++ b/src/Yaapii.Atoms/Text/SubText.cs
@@ -21,8 +21,6 @@
 // SOFTWARE.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using Yaapii.Atoms.Scalar;
 
 namespace Yaapii.Atoms.Text
@@ -34,7 +32,7 @@ namespace Yaapii.Atoms.Text
     {
         private readonly IText _origin;
         private readonly IScalar<Int32> _start;
-        private readonly IScalar<Int32> _end;
+        private readonly IScalar<Int32> _length;
 
         /// <summary>
         /// Extracted subtext from a <see cref="string"/>.
@@ -84,13 +82,13 @@ namespace Yaapii.Atoms.Text
         /// </summary>
         /// <param name="text">text to extract from</param>
         /// <param name="strt">where to start encapsulated in a scalar</param>
-        /// <param name="end">where to end encapsulated in a scalar</param>
+        /// <param name="len">where to end encapsulated in a scalar</param>
         public SubText(IText text, ScalarOf<Int32> strt,
-            ScalarOf<Int32> end)
+            ScalarOf<Int32> len)
         {
             this._origin = text;
             this._start = strt;
-            this._end = end;
+            this._length = len;
         }
 
         /// <summary>
@@ -101,7 +99,7 @@ namespace Yaapii.Atoms.Text
         {
             return this._origin.AsString().Substring(
                 this._start.Value(),
-                this._end.Value()
+                this._length.Value()
             );
         }
 

--- a/src/Yaapii.Atoms/Text/TextContains.cs
+++ b/src/Yaapii.Atoms/Text/TextContains.cs
@@ -28,15 +28,9 @@ namespace Yaapii.Atoms.Text
     /// <summary> Check if a text contains a pattern </summary>
     public sealed class TextContains : IScalar<bool>
     {
-        #region Fields
-
         private readonly IScalar<string> _inputValue;
         private readonly IScalar<string> _pattern;
         private readonly IScalar<StringComparison> _stringComparison;
-
-        #endregion Fields
-
-        #region Constructors
 
         /// <summary> Checks if a text contains a pattern using strings </summary>
         /// <param name="inputStr"> text as string </param>
@@ -72,17 +66,11 @@ namespace Yaapii.Atoms.Text
             _stringComparison = stringComparison;
         }
 
-        #endregion Constructors
-
-        #region Methods
-
         /// <summary> Returns if the inputValue contains the pattern </summary>
         /// <returns> bool </returns>
         public bool Value()
         {
             return _inputValue.Value().IndexOf(_pattern.Value(), _stringComparison.Value()) >= 0;
         }
-
-        #endregion Methods
     }
 }

--- a/tests/Yaapii.Atoms.Tests/Text/EndsWithTests.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/EndsWithTests.cs
@@ -1,0 +1,78 @@
+﻿using Xunit;
+using Yaapii.Atoms.Text;
+
+namespace Yaapii.Atoms.Tests.Text
+{
+    public sealed class EndsWithTests
+    {
+        [Fact]
+        public void FindsTextEnd()
+        {
+            var x =
+                new EndsWith(
+                    new TextOf("Im an text with a realy good end!"),
+                    new TextOf("od end!")
+                );
+            Assert.True(x.Value());
+        }
+
+        [Fact]
+        public void TakesTailAsString()
+        {
+            var x =
+                new EndsWith(
+                    new TextOf("Im an text with a realy good end!"),
+                    "od end!"
+                );
+            Assert.True(x.Value());
+        }
+
+        [Fact]
+        public void FailsOnWrongTail()
+        {
+            var x =
+                new EndsWith(
+                    new TextOf("Im an text with a realy good end!"),
+                    new TextOf("od end")
+                );
+            Assert.False(x.Value());
+        }
+
+        [Fact]
+        public void FailsOnCaseMismatch()
+        {
+            var x =
+                new EndsWith(
+                    new TextOf("Im an text with a realy good end!"),
+                    new TextOf("od enD!")
+                );
+            Assert.False(x.Value());
+        }
+
+        [Fact]
+        public void FindsMultilineTextEnd()
+        {
+            var x =
+                new EndsWith(
+                    new TextOf(
+                        "Im an text with a realy good end!" + System.Environment.NewLine +
+                        "But the end is here"),
+                    new TextOf("s here")
+                );
+            Assert.True(x.Value());
+        }
+
+        [Fact]
+        public void FailsOnWrongTailOfMultilineText()
+        {
+            var x =
+                new EndsWith(
+                    new TextOf(
+                        "Im an text with a realy good end!" + System.Environment.NewLine +
+                        "But the end is here"),
+                    new TextOf("od end!")
+                );
+            Assert.False(x.Value());
+        }
+    }
+}

--- a/tests/Yaapii.Atoms.Tests/Text/StartsWithTests.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/StartsWithTests.cs
@@ -1,0 +1,78 @@
+﻿using Xunit;
+using Yaapii.Atoms.Text;
+
+namespace Yaapii.Atoms.Tests.Text
+{
+    public sealed class StartsWithTests
+    {
+        [Fact]
+        public void FindsTextStart()
+        {
+            var x =
+                new StartsWith(
+                    new TextOf("Im an text with a realy good end!"),
+                    new TextOf("Im a")
+                );
+            Assert.True(x.Value());
+        }
+
+        [Fact]
+        public void TakesStartAsString()
+        {
+            var x =
+                new StartsWith(
+                    new TextOf("Im an text with a realy good end!"),
+                    "Im a"
+                );
+            Assert.True(x.Value());
+        }
+
+        [Fact]
+        public void FailsOnWrongStart()
+        {
+            var x =
+                new StartsWith(
+                    new TextOf("Im an text with a realy good end!"),
+                    new TextOf("m an")
+                );
+            Assert.False(x.Value());
+        }
+
+        [Fact]
+        public void FailsOnCaseMismatch()
+        {
+            var x =
+                new StartsWith(
+                    new TextOf("Im an text with a realy good end!"),
+                    new TextOf("im an")
+                );
+            Assert.False(x.Value());
+        }
+
+        [Fact]
+        public void FindsMultilineTextStart()
+        {
+            var x =
+                new StartsWith(
+                    new TextOf(
+                        "Im an text with a realy good end!" + System.Environment.NewLine +
+                        "But the end is here"),
+                    new TextOf("Im a")
+                );
+            Assert.True(x.Value());
+        }
+
+        [Fact]
+        public void FailsOnWrongStartOfMultilineText()
+        {
+            var x =
+                new StartsWith(
+                    new TextOf(
+                        "Im an text with a realy good end!" + System.Environment.NewLine +
+                        "But the end is here"),
+                    new TextOf("But t")
+                );
+            Assert.False(x.Value());
+        }
+    }
+}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
#149

### What is the new behavior?
We have two new classes which checks a text if it starts or ends with an given content:
- `StartsWith()`
- `EndsWit()`

### Does this PR introduce a breaking change? (check one with "x")
- [ ] Yes
- [x] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications

###  Other information
closes #149 