### PR TITLE
fix: TextOf - Ctor uses encoding now

### DIFF
--- a/src/Yaapii.Atoms/Text/TextOf.cs
+++ b/src/Yaapii.Atoms/Text/TextOf.cs
@@ -234,7 +234,7 @@ namespace Yaapii.Atoms.Text
             () => 
             {
                 var memoryStream = new MemoryStream(bytes.AsBytes());
-                return new StreamReader(memoryStream).ReadToEnd(); // removes the BOM from the Byte-Array
+                return new StreamReader(memoryStream, encoding).ReadToEnd(); // removes the BOM from the Byte-Array
             })
         { }
 

--- a/tests/Yaapii.Atoms.Tests/Text/TextOfTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/TextOfTest.cs
@@ -277,6 +277,18 @@ namespace Yaapii.Atoms.Text.Tests
         }
 
         [Fact]
+        public void ReadsBytesWithEncoding()
+        {
+            byte[] bytes = new byte[] { (byte)0xCA, (byte)0xFE };
+            Assert.True(
+                new TextOf(
+                    new BytesOf(bytes),
+                    Encoding.ASCII
+                ).AsString().CompareTo(Encoding.ASCII.GetString(bytes)) == 0,
+                "Can't read array of bytes");
+        }
+
+        [Fact]
         public void ComparesWithASubtext()
         {
             Assert.True(


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
Closes #218 

### What is the new behavior?
Ctor of TextOf uses the given Encoding to encode Stream

### Does this PR introduce a breaking change? (check one with "x")
- [ ] Yes
- [x] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications

###  Other information