### PR TITLE
fix: TextOf without CultureInvariant arg now uses InvariantCulture

### DIFF
--- a/src/Yaapii.Atoms/Text/TextOf.cs
+++ b/src/Yaapii.Atoms/Text/TextOf.cs
@@ -48,7 +48,7 @@ namespace Yaapii.Atoms.Text
         /// A <see cref="IText"/> out of a double
         /// </summary>
         /// <param name="input">a <see cref="double"/></param>
-        public TextOf(double input) : this(input.ToString())
+        public TextOf(double input) : this(input.ToString(CultureInfo.InvariantCulture))
         { }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace Yaapii.Atoms.Text
         /// A <see cref="IText"/> out of a float
         /// </summary>
         /// <param name="input">a <see cref="float"/></param>
-        public TextOf(float input) : this(input.ToString())
+        public TextOf(float input) : this(input.ToString(CultureInfo.InvariantCulture))
         { }
 
         /// <summary>

--- a/tests/Yaapii.Atoms.Tests/Text/TextOfTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/TextOfTest.cs
@@ -153,7 +153,7 @@ namespace Yaapii.Atoms.Text.Tests
 
             double doub = 0.2545;
 
-            var content = doub.ToString(CultureInfo.CurrentCulture);
+            var content = doub.ToString(CultureInfo.InvariantCulture);
 
             Assert.True(
                     new TextOf(doub
@@ -181,7 +181,7 @@ namespace Yaapii.Atoms.Text.Tests
             //var content = "0,2545";
 
             float doub = 0.2545f;
-            var content = doub.ToString(CultureInfo.CurrentCulture);
+            var content = doub.ToString(CultureInfo.InvariantCulture);
 
             Assert.True(
                     new TextOf(doub


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds
- [x] I merged the master into this branch before pushing
- [ ] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
Issue #228 
Other parts like NumberOf already defaults to InvariantCulture which results in wrong results when using `NumberOf(TextOf())`.

### What is the new behavior?
TextOf without a CultureInvariant arg now uses InvariantCulture in order to be consistent with NumberOf.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications

###  Other information