### PR TITLE
I272 Scalar.ItemAt doesn't throw given exception

### DIFF
--- a/src/Yaapii.Atoms/Enumerator/ItemAt.cs
+++ b/src/Yaapii.Atoms/Enumerator/ItemAt.cs
@@ -159,7 +159,10 @@ namespace Yaapii.Atoms.Enumerator
                 new FailPrecise(
                     new FailWhen(this._pos < 0),
                     new UnsupportedOperationException(
-                        "The position must be non-negative"
+                        new Formatted(
+                            "The position must be non-negative but is {0}",
+                            this._pos
+                        ).AsString()
                     )
                 ).Go();
 

--- a/src/Yaapii.Atoms/Enumerator/ItemAt.cs
+++ b/src/Yaapii.Atoms/Enumerator/ItemAt.cs
@@ -153,14 +153,16 @@ namespace Yaapii.Atoms.Enumerator
         /// <returns>the item</returns>
         public T Value()
         {
-            new FailPrecise(
-                new FailWhen(this._pos < 0),
-                new UnsupportedOperationException(
-                    new Formatted("The position must be non-negative but is {0}",
-                        this._pos).AsString())).Go();
             T ret;
             try
             {
+                new FailPrecise(
+                    new FailWhen(this._pos < 0),
+                    new UnsupportedOperationException(
+                        "The position must be non-negative"
+                    )
+                ).Go();
+
                 new FailPrecise(
                     new FailWhen(!this._src.MoveNext()),
                     new NoSuchElementException(

--- a/tests/Yaapii.Atoms.Tests/Enumerator/ItemAtTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Enumerator/ItemAtTest.cs
@@ -64,7 +64,7 @@ namespace Yaapii.Atoms.Enumerator.Tests
         [Fact]
         public void FailForNegativePositionTest()
         {
-            Assert.Throws<UnsupportedOperationException>(
+            Assert.Throws<NoSuchElementException>(
                     () => new ItemAt<int>(
                         new EnumerableOf<int>(1, 2, 3).GetEnumerator(),
                         -1

--- a/tests/Yaapii.Atoms.Tests/Scalar/ItemAtTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Scalar/ItemAtTest.cs
@@ -99,6 +99,18 @@ namespace Yaapii.Atoms.Scalar.Tests
         }
 
         [Fact]
+        public void FallbackShowsGivenErrorForNegativePosition()
+        {
+            Assert.Throws<NotFiniteNumberException>(() =>
+                new ItemAt<string>(
+                    new EnumerableOf<string>(),
+                    -12,
+                    new NotFiniteNumberException("Cannot do this!")
+                ).Value()
+            );
+        }
+
+        [Fact]
         public void StickyTest()
         {
             var list = new List<string>();


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
<!-- Describe the current behavior or link to a open issue -->

### What is the new behavior?
closes #272 

### Does this PR introduce a breaking change? (check one with "x")
- [x] Yes
- [ ] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications

possibly a breaking change, because i had to change an existing unit test, which was expecting the wrong type of error to be thrown. If some code depends on that specific error to be thrown, that code will be broken by this.
Enumerator.ItemAt now throws ```NoSuchElementException``` as part of a fallback function defined in one of its secondary constructors, when the position given to it is negative. Previously it threw ```UnsupportedOperationException``` in that case.
see changes made to tests/Yaapii.Atoms.Tests/Enumerator/ItemAtTest.cs, migration path for existing applications should be analogous to those changes.

###  Other information