### PR TITLE
i258 refactor: Text comparaison with the class Comparable

### DIFF
--- a/src/Yaapii.Atoms/IText.cs
+++ b/src/Yaapii.Atoms/IText.cs
@@ -21,15 +21,13 @@
 // SOFTWARE.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Yaapii.Atoms
 {
     ///
     /// Text. 
     ///
-    public interface IText : IEquatable<IText>
+    public interface IText
     {
         /// <summary>
         /// Get content as a string.

--- a/src/Yaapii.Atoms/Text/Base64Text.cs
+++ b/src/Yaapii.Atoms/Text/Base64Text.cs
@@ -62,15 +62,5 @@ namespace Yaapii.Atoms.Text
         {
             return this._origin.AsString();
         }
-
-        /// <summary>
-        /// Check for equality.
-        /// </summary>
-        /// <param name="text">other object to compare to</param>
-        /// <returns>true if equal.</returns>
-        public bool Equals(IText text)
-        {
-            return _origin.Equals(text);
-        }
     }
 }

--- a/src/Yaapii.Atoms/Text/Comparable.cs
+++ b/src/Yaapii.Atoms/Text/Comparable.cs
@@ -46,11 +46,6 @@ namespace Yaapii.Atoms.Text
             return this.text.AsString();
         }
 
-        public bool Equals(IText other)
-        {
-            return this.text.Equals(other);
-        }
-
         public int CompareTo(object obj)
         {
             new FailNull(

--- a/src/Yaapii.Atoms/Text/Formatted.cs
+++ b/src/Yaapii.Atoms/Text/Formatted.cs
@@ -143,25 +143,5 @@ namespace Yaapii.Atoms.Text
         {
             return String.Format(this._locale, _pattern.AsString(), _args.Value());
         }
-
-        /// <summary>
-        /// Compare to other text.
-        /// </summary>
-        /// <param name="text">text to compare to</param>
-        /// <returns>-1 if this is lower, 0 if equal, 1 if this is higher</returns>
-        public int CompareTo(IText text)
-        {
-            return this.AsString().CompareTo(text.AsString());
-        }
-
-        /// <summary>
-        /// Check for equality.
-        /// </summary>
-        /// <param name="other">other object to compare to</param>
-        /// <returns>true if equal.</returns>
-        public bool Equals(IText other)
-        {
-            return this.AsString().Equals(other);
-        }
     }
 }

--- a/src/Yaapii.Atoms/Text/HexOf.cs
+++ b/src/Yaapii.Atoms/Text/HexOf.cs
@@ -59,25 +59,5 @@ namespace Yaapii.Atoms.Text
             }
             return new string (hex);
         }
-
-        /// <summary>
-        /// Compare to other text.
-        /// </summary>
-        /// <param name="text">text to compare to</param>
-        /// <returns>-1 if this is lower, 0 if equal, 1 if this is higher</returns>
-        public int CompareTo(IText text)
-        {
-            return this.AsString().CompareTo(text.AsString());
-        }
-
-        /// <summary>
-        /// Check for equality.
-        /// </summary>
-        /// <param name="other">other object to compare to</param>
-        /// <returns>true if equal.</returns>
-        public bool Equals(IText other)
-        {
-            return CompareTo(other) == 0;
-        }
     }
 }

--- a/src/Yaapii.Atoms/Text/Joined.cs
+++ b/src/Yaapii.Atoms/Text/Joined.cs
@@ -139,25 +139,5 @@ namespace Yaapii.Atoms.Text
                     this._texts.Value()
                     ));
         }
-
-        /// <summary>
-        /// Compare to other text.
-        /// </summary>
-        /// <param name="text">text to compare to</param>
-        /// <returns>-1 if this is lower, 0 if equal, 1 if this is higher</returns>
-        public int CompareTo(IText text)
-        {
-            return this.AsString().CompareTo(text.AsString());
-        }
-
-        /// <summary>
-        /// Check for equality.
-        /// </summary>
-        /// <param name="other">other object to compare to</param>
-        /// <returns>true if equal.</returns>
-        public bool Equals(IText other)
-        {
-            return CompareTo(other) == 0;
-        }
     }
 }

--- a/src/Yaapii.Atoms/Text/Lower.cs
+++ b/src/Yaapii.Atoms/Text/Lower.cs
@@ -51,26 +51,5 @@ namespace Yaapii.Atoms.Text
         {
             return this._origin.AsString().ToLower();
         }
-
-        /// <summary>
-        /// Compare to other text.
-        /// </summary>
-        /// <param name="text">text to compare to</param>
-        /// <returns>-1 if this is lower, 0 if equal, 1 if this is higher</returns>
-        public int CompareTo(IText text)
-        {
-            return this.AsString().CompareTo(text.AsString());
-        }
-
-        /// <summary>
-        /// Check for equality.
-        /// </summary>
-        /// <param name="other">other object to compare to</param>
-        /// <returns>true if equal.</returns>
-        public bool Equals(IText other)
-        {
-            return CompareTo(other) == 0;
-        }
-
     }
 }

--- a/src/Yaapii.Atoms/Text/Normalized.cs
+++ b/src/Yaapii.Atoms/Text/Normalized.cs
@@ -58,25 +58,5 @@ namespace Yaapii.Atoms.Text
         {
             return Regex.Replace(new Trimmed(this._origin).AsString(), "\\s+", " ");
         }
-
-        /// <summary>
-        /// Compare to other text.
-        /// </summary>
-        /// <param name="text">text to compare to</param>
-        /// <returns>-1 if this is lower, 0 if equal, 1 if this is higher</returns>
-        public int CompareTo(IText text)
-        {
-            return this.AsString().CompareTo(text.AsString());
-        }
-
-        /// <summary>
-        /// Check for equality.
-        /// </summary>
-        /// <param name="other">other object to compare to</param>
-        /// <returns>true if equal.</returns>
-        public bool Equals(IText other)
-        {
-            return CompareTo(other) == 0;
-        }
     }
 }

--- a/src/Yaapii.Atoms/Text/NotNull.cs
+++ b/src/Yaapii.Atoms/Text/NotNull.cs
@@ -55,26 +55,5 @@ namespace Yaapii.Atoms.Text
             }
             return this._origin.AsString();
         }
-
-        /// <summary>
-        /// Compare to other text.
-        /// </summary>
-        /// <param name="text">text to compare to</param>
-        /// <returns>-1 if this is lower, 0 if equal, 1 if this is higher</returns>
-        public int CompareTo(IText text)
-        {
-            return this.AsString().CompareTo(text.AsString());
-        }
-
-        /// <summary>
-        /// Check for equality.
-        /// </summary>
-        /// <param name="other">other object to compare to</param>
-        /// <returns>true if equal.</returns>
-        public bool Equals(IText other)
-        {
-            return CompareTo(other) == 0;
-        }
-
     }
 }

--- a/src/Yaapii.Atoms/Text/Repeated.cs
+++ b/src/Yaapii.Atoms/Text/Repeated.cs
@@ -66,25 +66,5 @@ namespace Yaapii.Atoms.Text
             }
             return output.ToString();
         }
-
-        /// <summary>
-        /// Compare to other text.
-        /// </summary>
-        /// <param name="text">text to compare to</param>
-        /// <returns>-1 if this is lower, 0 if equal, 1 if this is higher</returns>
-        public int CompareTo(IText text)
-        {
-            return this.AsString().CompareTo(text.AsString());
-        }
-
-        /// <summary>
-        /// Check for equality.
-        /// </summary>
-        /// <param name="other">other object to compare to</param>
-        /// <returns>true if equal.</returns>
-        public bool Equals(IText other)
-        {
-            return CompareTo(other) == 0;
-        }
     }
 }

--- a/src/Yaapii.Atoms/Text/Replaced.cs
+++ b/src/Yaapii.Atoms/Text/Replaced.cs
@@ -21,8 +21,6 @@
 // SOFTWARE.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Yaapii.Atoms.Text
 {
@@ -56,26 +54,5 @@ namespace Yaapii.Atoms.Text
         {
             return this._origin.AsString().Replace(this._needle, this._replacement);
         }
-
-        /// <summary>
-        /// Compare to other text.
-        /// </summary>
-        /// <param name="text">text to compare to</param>
-        /// <returns>-1 if this is lower, 0 if equal, 1 if this is higher</returns>
-        public int CompareTo(IText text)
-        {
-            return this.AsString().CompareTo(text.AsString());
-        }
-
-        /// <summary>
-        /// Check for equality.
-        /// </summary>
-        /// <param name="text">other object to compare to</param>
-        /// <returns>true if equal.</returns>
-        public bool Equals(IText text)
-        {
-            return this.CompareTo(text) == 0;
-        }
-
     }
 }

--- a/src/Yaapii.Atoms/Text/Reversed.cs
+++ b/src/Yaapii.Atoms/Text/Reversed.cs
@@ -21,8 +21,6 @@
 // SOFTWARE.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Yaapii.Atoms.Text
 {
@@ -56,26 +54,6 @@ namespace Yaapii.Atoms.Text
                 reverseTxt += chararray.GetValue(i);
             }
             return reverseTxt;
-        }
-
-        /// <summary>
-        /// Compare to other text.
-        /// </summary>
-        /// <param name="text">text to compare to</param>
-        /// <returns>-1 if this is lower, 0 if equal, 1 if this is higher</returns>
-        public int CompareTo(IText text)
-        {
-            return this.AsString().CompareTo(text.AsString());
-        }
-
-        /// <summary>
-        /// Check for equality.
-        /// </summary>
-        /// <param name="other">other object to compare to</param>
-        /// <returns>true if equal.</returns>
-        public bool Equals(IText other)
-        {
-            return CompareTo(other) == 0;
         }
     }
 }

--- a/src/Yaapii.Atoms/Text/Rotated.cs
+++ b/src/Yaapii.Atoms/Text/Rotated.cs
@@ -21,7 +21,6 @@
 // SOFTWARE.
 
 using System;
-using System.Collections.Generic;
 using System.Text;
 
 namespace Yaapii.Atoms.Text
@@ -69,16 +68,5 @@ namespace Yaapii.Atoms.Text
             }
             return text;
         }
-
-        /// <summary>
-        /// Check for equality.
-        /// </summary>
-        /// <param name="text">other object to compare to</param>
-        /// <returns>true if equal.</returns>
-        public bool Equals(IText text)
-        {
-            return this.AsString().CompareTo(text.AsString()) == 0;
-        }
-
     }
 }

--- a/src/Yaapii.Atoms/Text/SubText.cs
+++ b/src/Yaapii.Atoms/Text/SubText.cs
@@ -102,25 +102,5 @@ namespace Yaapii.Atoms.Text
                 this._length.Value()
             );
         }
-
-        /// <summary>
-        /// Compare to other text.
-        /// </summary>
-        /// <param name="text">text to compare to</param>
-        /// <returns>-1 if this is lower, 0 if equal, 1 if this is higher</returns>
-        public int CompareTo(IText text)
-        {
-            return this.AsString().CompareTo(text.AsString());
-        }
-
-        /// <summary>
-        /// Check for equality.
-        /// </summary>
-        /// <param name="text">other object to compare to</param>
-        /// <returns>true if equal.</returns>
-        public bool Equals(IText text)
-        {
-            return this.CompareTo(text) == 0;
-        }
     }
 }

--- a/src/Yaapii.Atoms/Text/TextBase64.cs
+++ b/src/Yaapii.Atoms/Text/TextBase64.cs
@@ -21,10 +21,7 @@
 // SOFTWARE.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using Yaapii.Atoms.Bytes;
-using Yaapii.Atoms.IO;
 
 namespace Yaapii.Atoms.Text
 {
@@ -59,12 +56,6 @@ namespace Yaapii.Atoms.Text
         public string AsString()
         {
             return origin.AsString();
-                
-        }
-
-        public bool Equals(IText other)
-        {
-            return origin.Equals(other);
         }
     }
 }

--- a/src/Yaapii.Atoms/Text/TextOf.cs
+++ b/src/Yaapii.Atoms/Text/TextOf.cs
@@ -26,7 +26,6 @@ using System.IO;
 using System.Text;
 using Yaapii.Atoms.Bytes;
 using Yaapii.Atoms.IO;
-using Yaapii.Atoms.Scalar;
 
 #pragma warning disable MaxClassLength // Class length max
 namespace Yaapii.Atoms.Text
@@ -307,46 +306,6 @@ namespace Yaapii.Atoms.Text
         public String AsString()
         {
             return this.origin.Value;
-        }
-
-        /// <summary>
-        /// Compares to another text.
-        /// </summary>
-        /// <param name="text"></param>
-        /// <returns></returns>
-        public int CompareTo(IText text)
-        {
-            return this.AsString().CompareTo(text.AsString());
-        }
-
-        /// <summary>
-        /// Checks for equality
-        /// </summary>
-        /// <param name="obj"></param>
-        /// <returns></returns>
-        public override bool Equals(object obj)
-        {
-            if (obj as IText == null) return false;
-            return this.AsString().CompareTo((obj as IText).AsString()) == 0;
-        }
-
-        /// <summary>
-        /// Checks for equality
-        /// </summary>
-        /// <param name="text"></param>
-        /// <returns></returns>
-        public bool Equals(IText text)
-        {
-            return Equals(text as object);
-        }
-
-        /// <summary>
-        /// Hashcode for this text
-        /// </summary>
-        /// <returns></returns>
-        public override int GetHashCode()
-        {
-            return base.GetHashCode();
         }
     }
 }

--- a/src/Yaapii.Atoms/Text/TextUri.cs
+++ b/src/Yaapii.Atoms/Text/TextUri.cs
@@ -21,8 +21,6 @@
 // SOFTWARE.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Yaapii.Atoms.Text
 {

--- a/src/Yaapii.Atoms/Text/Trimmed.cs
+++ b/src/Yaapii.Atoms/Text/Trimmed.cs
@@ -163,25 +163,5 @@ namespace Yaapii.Atoms.Text
         {
             return this.trimmedText.Value().AsString();
         }
-
-        /// <summary>
-        /// Compare to other text.
-        /// </summary>
-        /// <param name="text">text to compare to</param>
-        /// <returns>-1 if this is lower, 0 if equal, 1 if this is higher</returns>
-        public int CompareTo(IText text)
-        {
-            return this.AsString().CompareTo(text.AsString());
-        }
-
-        /// <summary>
-        /// Check for equality.
-        /// </summary>
-        /// <param name="other">other object to compare to</param>
-        /// <returns>true if equal.</returns>
-        public bool Equals(IText other)
-        {
-            return this.AsString().Equals(other.AsString());
-        }
     }
 }

--- a/src/Yaapii.Atoms/Text/TrimmedLeft.cs
+++ b/src/Yaapii.Atoms/Text/TrimmedLeft.cs
@@ -152,15 +152,5 @@ namespace Yaapii.Atoms.Text
         {
             return this.trimmedText.Value().AsString();
         }
-
-        /// <summary>
-        /// Check for equality.
-        /// </summary>
-        /// <param name="other">other object to compare to</param>
-        /// <returns>true if equal.</returns>
-        public bool Equals(IText other)
-        {
-            return this.AsString().Equals(other.AsString());
-        }
     }
 }

--- a/src/Yaapii.Atoms/Text/TrimmedRight.cs
+++ b/src/Yaapii.Atoms/Text/TrimmedRight.cs
@@ -153,15 +153,5 @@ namespace Yaapii.Atoms.Text
         {
             return this.trimmedText.Value().AsString();
         }
-
-        /// <summary>
-        /// Check for equality.
-        /// </summary>
-        /// <param name="other">other object to compare to</param>
-        /// <returns>true if equal.</returns>
-        public bool Equals(IText other)
-        {
-            return this.AsString().Equals(other.AsString());
-        }
     }
 }

--- a/src/Yaapii.Atoms/Text/Upper.cs
+++ b/src/Yaapii.Atoms/Text/Upper.cs
@@ -21,9 +21,6 @@
 // SOFTWARE.
 
 using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Text;
 
 namespace Yaapii.Atoms.Text
 {
@@ -50,26 +47,6 @@ namespace Yaapii.Atoms.Text
         public String AsString()
         {
             return this._origin.AsString().ToUpperInvariant();
-        }
-
-        /// <summary>
-        /// Compare to other text.
-        /// </summary>
-        /// <param name="text">text to compare to</param>
-        /// <returns>-1 if this is lower, 0 if equal, 1 if this is higher</returns>
-        public int CompareTo(IText text)
-        {
-            return this.AsString().CompareTo(text.AsString());
-        }
-
-        /// <summary>
-        /// Check for equality.
-        /// </summary>
-        /// <param name="other">other object to compare to</param>
-        /// <returns>true if equal.</returns>
-        public bool Equals(Atoms.IText other)
-        {
-            return other.AsString().Equals(this.AsString());
         }
     }
 }

--- a/tests/Yaapii.Atoms.Tests/Text/Base64TextTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/Base64TextTest.cs
@@ -52,13 +52,15 @@ namespace Yaapii.Atoms.Text.Tests
                 ).Value();
 
                 Assert.True(
-                    new Base64Text(
-                        new TextOf(
-                            new Uri(tempFile.Value())
+                    new Comparable(
+                        new Base64Text(
+                            new TextOf(
+                                new Uri(tempFile.Value())
+                            )
                         )
-                    ).Equals(
+                    ).CompareTo(
                         new TextOf(text)
-                    )
+                    ) == 0
                 );
             }
         }

--- a/tests/Yaapii.Atoms.Tests/Text/TextBase64Tests.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/TextBase64Tests.cs
@@ -52,12 +52,16 @@ namespace Yaapii.Atoms.Text.Tests
                 ).Value();
 
                 Assert.True(
-                    new TextOf(
-                        new Uri(tempFile.Value())
-                    ).Equals(
-                    new TextBase64(
-                        new TextOf(text)
-                    )));
+                    new Comparable(
+                        new TextOf(
+                            new Uri(tempFile.Value())
+                        )
+                    ).CompareTo(
+                        new TextBase64(
+                            new TextOf(text)
+                        )
+                    ) == 0
+                );
             }
         }
     }

--- a/tests/Yaapii.Atoms.Tests/Text/TextOfTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/TextOfTest.cs
@@ -306,7 +306,7 @@ namespace Yaapii.Atoms.Text.Tests
         public void ComparesWithASubtext()
         {
             Assert.True(
-            new TextOf("here to there").CompareTo(
+            new Comparable(new TextOf("here to there")).CompareTo(
                 new SubText("from here to there", 5)
             ) == 0,
             "Can't compare sub texts");

--- a/tests/Yaapii.Atoms.Tests/Text/TrimmedLeftTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/TrimmedLeftTest.cs
@@ -114,13 +114,5 @@ namespace Yaapii.Atoms.Text.Tests
                 new TrimmedLeft(new TextOf(" \b   \t      Hello! \t \b   \t      H"), new ScalarOf<IText>(() => new TextOf(" \b   \t      H"))).AsString() == "ello! \t \b   \t      H"
             );
         }
-
-        [Fact]
-        public void CanCheckTextEquality()
-        {
-            Assert.True(
-                new TrimmedLeft(new TextOf(" \b   \t      Hello! \t \b   \t      ")).Equals(new TextOf("Hello! \t \b   \t      "))
-            );
-        }
     }
 }

--- a/tests/Yaapii.Atoms.Tests/Text/TrimmedRightTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/TrimmedRightTest.cs
@@ -114,13 +114,5 @@ namespace Yaapii.Atoms.Text.Tests
                 new TrimmedRight(new TextOf(" \b   \t      Hello! \t \b   \t      H"), new ScalarOf<IText>(() => new TextOf(" \b   \t      H"))).AsString() == " \b   \t      Hello! \t"
             );
         }
-
-        [Fact]
-        public void CanCheckTextEquality()
-        {
-            Assert.True(
-                new TrimmedRight(new TextOf(" \b   \t      Hello! \t \b   \t      ")).Equals(new TextOf(" \b   \t      Hello!"))
-            );
-        }
     }
 }

--- a/tests/Yaapii.Atoms.Tests/Text/TrimmedTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/TrimmedTest.cs
@@ -117,21 +117,5 @@ namespace Yaapii.Atoms.Text.Tests
                 new Trimmed(new TextOf(" \b   \t      Hello! \t \b   \t      H"), new ScalarOf<IText>(() => new TextOf(" \b   \t      H"))).AsString() == "ello! \t"
             );
         }
-
-        [Fact]
-        public void CanCompareTexts()
-        {
-            Assert.True(
-                new Trimmed(new TextOf(" \b   \t      Hello! \t \b   \t      ")).CompareTo(new TextOf("Hello!")) == 0
-            );
-        }
-
-        [Fact]
-        public void CanCheckTextEquality()
-        {
-            Assert.True(
-                new Trimmed(new TextOf(" \b   \t      Hello! \t \b   \t      ")).Equals(new TextOf("Hello!"))
-            );
-        }
     }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
The interface IText and implementations defined the method Equals.
Some implementations of IText have a method CompareTo.

### What is the new behavior?
The interface IText don't have method Equals.
The implementations of IText don't override the method Equals.
The implementations of IText  don't have method CompareTo.

### Does this PR introduce a breaking change? (check one with "x")
- [x] Yes
- [ ] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications
Before, the Equals method in implementations of IText check the value. 
Now, the Equals method in implementations of IText come from the base class (mainly Object) and check the reference.

###  Other information