### PR TITLE
LazyMap: prevent value building

### DIFF
--- a/src/Yaapii.Atoms/IKvp.cs
+++ b/src/Yaapii.Atoms/IKvp.cs
@@ -5,12 +5,13 @@ using System.Text;
 namespace Yaapii.Atoms
 {
     /// <summary>
-    /// A key-value pair string to strnig to add to a map.
+    /// A key-value pair string to string to add to a map.
     /// </summary>
     public interface IKvp
     {
         string Key();
         string Value();
+        bool IsLazy();
     }
 
     /// <summary>
@@ -20,6 +21,7 @@ namespace Yaapii.Atoms
     {
         string Key();
         TValue Value();
+        bool IsLazy();
     }
 
     /// <summary>
@@ -29,5 +31,6 @@ namespace Yaapii.Atoms
     {
         TKey Key();
         TValue Value();
+        bool IsLazy();
     }
 }

--- a/src/Yaapii.Atoms/Map/FkKvp.cs
+++ b/src/Yaapii.Atoms/Map/FkKvp.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Yaapii.Atoms.Lookup
+{
+    /// <summary>
+    /// Fake Kvp
+    /// </summary>
+    public sealed class FkKvp<TKey, TValue> : IKvp<TKey, TValue>
+    {
+        private readonly Func<TKey> keyFunc;
+        private readonly Func<TValue> valueFunc;
+        private readonly Func<bool> isLazyFunc;
+
+        /// <summary>
+        /// Fake Kvp
+        /// </summary>
+        public FkKvp(Func<TKey> keyFunc, Func<TValue> valueFunc, Func<bool> isLazyFunc) {
+            this.keyFunc = keyFunc;
+            this.valueFunc = valueFunc;
+            this.isLazyFunc = isLazyFunc;
+        }
+
+        public TValue Value()
+        {
+            return this.valueFunc();
+        }
+
+        public TKey Key()
+        {
+            return this.keyFunc();
+        }
+
+        public bool IsLazy()
+        {
+            return this.isLazyFunc();
+        }
+    }
+}

--- a/src/Yaapii.Atoms/Map/Kvp.Envelope.cs
+++ b/src/Yaapii.Atoms/Map/Kvp.Envelope.cs
@@ -46,6 +46,11 @@ namespace Yaapii.Atoms.Lookup
             {
                 return this.origin.Value();
             }
+
+            public bool IsLazy()
+            {
+                return this.origin.IsLazy();
+            }
         }
 
         /// <summary>
@@ -73,6 +78,11 @@ namespace Yaapii.Atoms.Lookup
             {
                 return this.origin.Value();
             }
+
+            public bool IsLazy()
+            {
+                return this.origin.IsLazy();
+            }
         }
 
         /// <summary>
@@ -99,6 +109,11 @@ namespace Yaapii.Atoms.Lookup
             public TValue Value()
             {
                 return this.origin.Value();
+            }
+
+            public bool IsLazy()
+            {
+                return this.origin.IsLazy();
             }
         }
     }

--- a/src/Yaapii.Atoms/Map/Kvp.Of.cs
+++ b/src/Yaapii.Atoms/Map/Kvp.Of.cs
@@ -37,57 +37,66 @@ namespace Yaapii.Atoms.Lookup
         {
             private readonly Sticky<KeyValuePair<string, Func<string>>> entry;
             private readonly Sticky<string> value;
+            private readonly bool isLazy;
 
             /// <summary>
-            /// Key-value pair matching a string to specified type value.
+            /// Key-value pair made of strings.
             /// </summary>
-            public Of(string key, string value) : this(
-                () => new KeyValuePair<string, Func<string>>(key, () => value)
-            )
+            public Of(IText key, Func<string> value)
+                : this(key.AsString(), value)
             { }
 
             /// <summary>
-            /// Key-value pair matching a string to specified type value.
+            /// Key-value pair made of strings.
+            /// </summary>
+            public Of(IText key, string value)
+                : this(key.AsString(), value)
+            { }
+
+            /// <summary>
+            /// Key-value pair made of strings.
             /// </summary>
             public Of(string key, Func<string> value) : this(
-                () => new KeyValuePair<string, Func<string>>(key, value)
+                () => new KeyValuePair<string, Func<string>>(key, value),
+                true
             )
             { }
 
             /// <summary>
-            /// Key-value pair matching a string to specified type value.
+            /// Key-value pair made of strings.
             /// </summary>
-            public Of(IText key, Func<string> value) : this(
-                () => new KeyValuePair<string, Func<string>>(
-                    key.AsString(), value
-                )
+            public Of(string key, string value) : this(
+                () => new KeyValuePair<string, Func<string>>(key, () => value),
+                false
             )
             { }
 
             /// <summary>
-            /// Key-value pair matching a string to specified type value.
-            /// </summary>
-            public Of(IText key, string value) : this(
-                () => new KeyValuePair<string, Func<string>>(
-                    key.AsString(),
-                    () => value
-                )
-            )
-            { }
-
-            /// <summary>
-            /// Key-value pair matching a string to specified type value.
+            /// Key-value pair made of strings.
             /// </summary>
             public Of(IScalar<KeyValuePair<string, string>> kvp)
+                : this(() => kvp.Value())
             { }
 
-            private Of(Func<KeyValuePair<string, Func<string>>> kvp)
+            /// <summary>
+            /// Key-value pair made of strings.
+            /// </summary>
+            public Of(Func<KeyValuePair<string, string>> kvp)
+                : this(() =>
+                {
+                    var simple = kvp.Invoke();
+                    return new KeyValuePair<string, Func<string>>(simple.Key, () => simple.Value);
+                }, true)
+            { }
+
+            private Of(Func<KeyValuePair<string, Func<string>>> kvp, bool isLazy)
             {
                 this.entry =
                     new Sticky<KeyValuePair<string, Func<string>>>(
                         () => kvp.Invoke()
                     );
                 this.value = new Sticky<string>(() => this.entry.Value().Value.Invoke());
+                this.isLazy = isLazy;
             }
 
             public string Key()
@@ -99,6 +108,11 @@ namespace Yaapii.Atoms.Lookup
             {
                 return this.value.Value();
             }
+
+            public bool IsLazy()
+            {
+                return this.isLazy;
+            }
         }
 
         /// <summary>
@@ -108,41 +122,37 @@ namespace Yaapii.Atoms.Lookup
         {
             private readonly Sticky<KeyValuePair<string, Func<TValue>>> entry;
             private readonly Sticky<TValue> value;
+            private readonly bool isLazy;
 
             /// <summary>
             /// Key-value pair matching a string to specified type value.
             /// </summary>
-            public Of(string key, TValue value) : this(
-                key, () => value
-            )
+            public Of(IText key, Func<TValue> value)
+                : this(key.AsString(), value)
+            { }
+
+            /// <summary>
+            /// Key-value pair matching a string to specified type value.
+            /// </summary>
+            public Of(IText key, TValue value)
+                : this(key.AsString(), value)
             { }
 
             /// <summary>
             /// Key-value pair matching a string to specified type value.
             /// </summary>
             public Of(string key, Func<TValue> value) : this(
-                () => new KeyValuePair<string, Func<TValue>>(key, value)
+                () => new KeyValuePair<string, Func<TValue>>(key, value),
+                true
             )
             { }
 
             /// <summary>
             /// Key-value pair matching a string to specified type value.
             /// </summary>
-            public Of(IText key, Func<TValue> value) : this(
-                () => new KeyValuePair<string, Func<TValue>>(
-                    key.AsString(), value
-                )
-            )
-            { }
-
-            /// <summary>
-            /// Key-value pair matching a string to specified type value.
-            /// </summary>
-            public Of(IText key, TValue value) : this(
-                () => new KeyValuePair<string, Func<TValue>>(
-                    key.AsString(),
-                    () => value
-                )
+            public Of(string key, TValue value) : this(
+                () => new KeyValuePair<string, Func<TValue>>(key, () => value),
+                false
             )
             { }
 
@@ -150,15 +160,28 @@ namespace Yaapii.Atoms.Lookup
             /// Key-value pair matching a string to specified type value.
             /// </summary>
             public Of(IScalar<KeyValuePair<string, TValue>> kvp)
+                : this(() => kvp.Value())
             { }
 
-            private Of(Func<KeyValuePair<string, Func<TValue>>> kvp)
+            /// <summary>
+            /// Key-value pair matching a string to specified type value.
+            /// </summary>
+            public Of(Func<KeyValuePair<string, TValue>> kvp)
+                : this(() =>
+                {
+                    var simple = kvp.Invoke();
+                    return new KeyValuePair<string, Func<TValue>>(simple.Key, () => simple.Value);
+                }, true)
+            { }
+
+            private Of(Func<KeyValuePair<string, Func<TValue>>> kvp, bool isLazy)
             {
                 this.entry =
                     new Sticky<KeyValuePair<string, Func<TValue>>>(
                         () => kvp.Invoke()
                     );
                 this.value = new Sticky<TValue>(() => this.entry.Value().Value.Invoke());
+                this.isLazy = isLazy;
             }
 
             public string Key()
@@ -170,6 +193,11 @@ namespace Yaapii.Atoms.Lookup
             {
                 return this.value.Value();
             }
+
+            public bool IsLazy()
+            {
+                return this.isLazy;
+            }
         }
 
         /// <summary>
@@ -179,36 +207,52 @@ namespace Yaapii.Atoms.Lookup
         {
             private readonly Sticky<KeyValuePair<TKey, Func<TValue>>> entry;
             private readonly Sticky<TValue> value;
+            private readonly bool isLazy;
 
             /// <summary>
-            /// Key-value pair matching a string to specified type value.
+            /// Key-value pair matching a key type to specified type value.
             /// </summary>
             public Of(TKey key, Func<TValue> value) : this(
-                () => new KeyValuePair<TKey, Func<TValue>>(key, value)
+                () => new KeyValuePair<TKey, Func<TValue>>(key, value),
+                true
             )
             { }
 
             /// <summary>
-            /// Key-value pair matching a string to specified type value.
+            /// Key-value pair matching a key type to specified type value.
             /// </summary>
             public Of(TKey key, TValue value) : this(
-                () => new KeyValuePair<TKey, Func<TValue>>(key, () => value)
+                () => new KeyValuePair<TKey, Func<TValue>>(key, () => value),
+                false
             )
             { }
 
             /// <summary>
-            /// Key-value pair matching a string to specified type value.
+            /// Key-value pair matching a key type to specified type value.
             /// </summary>
             public Of(IScalar<KeyValuePair<TKey, TValue>> kvp)
+                : this(() => kvp.Value())
             { }
 
-            private Of(Func<KeyValuePair<TKey, Func<TValue>>> kvp)
+            /// <summary>
+            /// Key-value pair matching a key type to specified type value.
+            /// </summary>
+            public Of(Func<KeyValuePair<TKey, TValue>> kvp)
+                : this(() =>
+                {
+                    var simple = kvp.Invoke();
+                    return new KeyValuePair<TKey, Func<TValue>>(simple.Key, () => simple.Value);
+                }, true)
+            { }
+
+            private Of(Func<KeyValuePair<TKey, Func<TValue>>> kvp, bool isLazy)
             {
                 this.entry =
                     new Sticky<KeyValuePair<TKey, Func<TValue>>>(
                         () => kvp.Invoke()
                     );
                 this.value = new Sticky<TValue>(() => this.entry.Value().Value.Invoke());
+                this.isLazy = isLazy;
             }
 
             public TKey Key()
@@ -219,6 +263,11 @@ namespace Yaapii.Atoms.Lookup
             public TValue Value()
             {
                 return this.value.Value();
+            }
+
+            public bool IsLazy()
+            {
+                return this.isLazy;
             }
         }
     }

--- a/src/Yaapii.Atoms/Map/LazyDict.cs
+++ b/src/Yaapii.Atoms/Map/LazyDict.cs
@@ -39,6 +39,7 @@ namespace Yaapii.Atoms.Lookup
         private readonly IDictionary<string, Sticky<string>> map;
         private readonly UnsupportedOperationException rejectReadException = new UnsupportedOperationException("Writing is not supported, it's a read-only map");
         private readonly bool rejectBuildingAllValues;
+        private readonly Sticky<bool> anyValueIsLazy;
 
         /// <summary>
         /// ctor
@@ -68,6 +69,17 @@ namespace Yaapii.Atoms.Lookup
                     }
                     return dict;
                 });
+            this.anyValueIsLazy = new Sticky<bool>(() =>
+            {
+                return new Ternary<IFail, bool>(
+                    new LengthOf(kvps).Value() == 0,
+                    false,
+                    new Reduced<bool>(
+                        new Enumerable.Mapped<IKvp, bool>(kvp => kvp.IsLazy(), kvps),
+                        (a, b) => a || b
+                    ).Value()
+                ).Value();
+            });
         }
 
         /// <summary>
@@ -89,7 +101,7 @@ namespace Yaapii.Atoms.Lookup
         {
             get
             {
-                if (this.rejectBuildingAllValues)
+                if (this.rejectBuildingAllValues && this.anyValueIsLazy.Value())
                 {
                     throw new InvalidOperationException(
                         "Cannot get values because this is a lazy dictionary."
@@ -171,7 +183,7 @@ namespace Yaapii.Atoms.Lookup
         /// <param name="arrayIndex">index to start</param>
         public void CopyTo(KeyValuePair<string, string>[] array, int arrayIndex)
         {
-            if (this.rejectBuildingAllValues)
+            if (this.rejectBuildingAllValues && this.anyValueIsLazy.Value())
             {
                 throw new InvalidOperationException("Cannot copy entries because this is a lazy dictionary."
                     + " Copying the entries would build all values."
@@ -197,7 +209,7 @@ namespace Yaapii.Atoms.Lookup
         /// <returns>The enumerator</returns>
         public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
         {
-            if (this.rejectBuildingAllValues)
+            if (this.rejectBuildingAllValues && this.anyValueIsLazy.Value())
             {
                 throw new InvalidOperationException(
                     "Cannot get the enumerator because this is a lazy dictionary."
@@ -266,6 +278,7 @@ namespace Yaapii.Atoms.Lookup
         private readonly IDictionary<string, Sticky<Value>> map;
         private readonly UnsupportedOperationException rejectReadException = new UnsupportedOperationException("Writing is not supported, it's a read-only map");
         private readonly bool rejectBuildingAllValues;
+        private readonly Sticky<bool> anyValueIsLazy;
 
         /// <summary>
         /// ctor
@@ -295,6 +308,17 @@ namespace Yaapii.Atoms.Lookup
                     }
                     return dict;
                 });
+            this.anyValueIsLazy = new Sticky<bool>(() =>
+            {
+                return new Ternary<IFail, bool>(
+                    new LengthOf(kvps).Value() == 0,
+                    false,
+                    new Reduced<bool>(
+                        new Enumerable.Mapped<IKvp<Value>, bool>(kvp => kvp.IsLazy(), kvps),
+                        (a, b) => a || b
+                    ).Value()
+                ).Value();
+            });
         }
 
         /// <summary>
@@ -316,7 +340,7 @@ namespace Yaapii.Atoms.Lookup
         {
             get
             {
-                if (this.rejectBuildingAllValues)
+                if (this.rejectBuildingAllValues && this.anyValueIsLazy.Value())
                 {
                     throw new InvalidOperationException(
                         "Cannot get values because this is a lazy dictionary."
@@ -397,7 +421,7 @@ namespace Yaapii.Atoms.Lookup
         /// <param name="arrayIndex">index to start</param>
         public void CopyTo(KeyValuePair<string, Value>[] array, int arrayIndex)
         {
-            if (this.rejectBuildingAllValues)
+            if (this.rejectBuildingAllValues && this.anyValueIsLazy.Value())
             {
                 throw new InvalidOperationException("Cannot copy entries because this is a lazy dictionary."
                     + " Copying the entries would build all values."
@@ -423,7 +447,7 @@ namespace Yaapii.Atoms.Lookup
         /// <returns>The enumerator</returns>
         public IEnumerator<KeyValuePair<string, Value>> GetEnumerator()
         {
-            if (this.rejectBuildingAllValues)
+            if (this.rejectBuildingAllValues && this.anyValueIsLazy.Value())
             {
                 throw new InvalidOperationException(
                     "Cannot get the enumerator because this is a lazy dictionary."
@@ -492,6 +516,7 @@ namespace Yaapii.Atoms.Lookup
         private readonly IDictionary<Key, Sticky<Value>> map;
         private readonly UnsupportedOperationException rejectReadException = new UnsupportedOperationException("Writing is not supported, it's a read-only map");
         private readonly bool rejectBuildingAllValues;
+        private readonly Sticky<bool> anyValueIsLazy;
 
         /// <summary>
         /// ctor
@@ -521,6 +546,18 @@ namespace Yaapii.Atoms.Lookup
                     }
                     return dict;
                 });
+            this.anyValueIsLazy = new Sticky<bool>(() =>
+            {
+                return new Ternary<IFail, bool>(
+                    new LengthOf(kvps).Value() == 0,
+                    false,
+                    new Reduced<bool>(
+                        new Enumerable.Mapped<IKvp<Key, Value>, bool>(kvp => kvp.IsLazy(), kvps),
+                        (a, b) => a || b
+                    ).Value()
+                ).Value();
+            });
+
         }
 
         /// <summary>
@@ -542,7 +579,7 @@ namespace Yaapii.Atoms.Lookup
         {
             get
             {
-                if (this.rejectBuildingAllValues)
+                if (this.rejectBuildingAllValues && this.anyValueIsLazy.Value())
                 {
                     throw new InvalidOperationException(
                         "Cannot get all values because this is a lazy dictionary."
@@ -624,7 +661,7 @@ namespace Yaapii.Atoms.Lookup
         /// <param name="arrayIndex">index to start</param>
         public void CopyTo(KeyValuePair<Key, Value>[] array, int arrayIndex)
         {
-            if (this.rejectBuildingAllValues)
+            if (this.rejectBuildingAllValues && this.anyValueIsLazy.Value())
             {
                 throw new InvalidOperationException(
                     "Cannot copy entries because this is a lazy dictionary."
@@ -651,7 +688,7 @@ namespace Yaapii.Atoms.Lookup
         /// <returns>The enumerator</returns>
         public IEnumerator<KeyValuePair<Key, Value>> GetEnumerator()
         {
-            if (this.rejectBuildingAllValues)
+            if (this.rejectBuildingAllValues && this.anyValueIsLazy.Value())
             {
                 throw new InvalidOperationException(
                     "Cannot get the enumerator because this is a lazy dictionary."

--- a/src/Yaapii.Atoms/Map/LazyDict.cs
+++ b/src/Yaapii.Atoms/Map/LazyDict.cs
@@ -38,18 +38,26 @@ namespace Yaapii.Atoms.Lookup
     {
         private readonly IDictionary<string, Sticky<string>> map;
         private readonly UnsupportedOperationException rejectReadException = new UnsupportedOperationException("Writing is not supported, it's a read-only map");
+        private readonly bool rejectBuildingAllValues;
 
         /// <summary>
         /// ctor
         /// </summary>
-        public LazyDict(params IKvp[] kvps) : this(new Many.Live<IKvp>(kvps))
+        public LazyDict(params IKvp[] kvps) : this(new Many.Live<IKvp>(kvps), true)
         { }
 
         /// <summary>
         /// ctor
         /// </summary>
-        public LazyDict(IEnumerable<IKvp> kvps)
+        public LazyDict(bool rejectBuildingAllKeys, params IKvp[] kvps) : this(new Many.Live<IKvp>(kvps), rejectBuildingAllKeys)
+        { }
+
+        /// <summary>
+        /// ctor
+        /// </summary>
+        public LazyDict(IEnumerable<IKvp> kvps, bool rejectBuildingAllValues = true)
         {
+            this.rejectBuildingAllValues = rejectBuildingAllValues;
             this.map =
                 new Map.Of<Sticky<string>>(() =>
                 {
@@ -81,6 +89,13 @@ namespace Yaapii.Atoms.Lookup
         {
             get
             {
+                if (this.rejectBuildingAllValues)
+                {
+                    throw new InvalidOperationException(
+                        "Cannot get values because this is a lazy dictionary."
+                        + " Getting the values would build all keys."
+                        + " If you need this behaviour, set the ctor param 'rejectBuildingAllValues' to false.");
+                }
                 return
                     new List.Live<string>(
                        new Enumerable.Mapped<Sticky<string>, string>(
@@ -156,6 +171,12 @@ namespace Yaapii.Atoms.Lookup
         /// <param name="arrayIndex">index to start</param>
         public void CopyTo(KeyValuePair<string, string>[] array, int arrayIndex)
         {
+            if (this.rejectBuildingAllValues)
+            {
+                throw new InvalidOperationException("Cannot copy entries because this is a lazy dictionary."
+                    + " Copying the entries would build all values."
+                    + " If you need this behaviour, set the ctor param 'rejectBuildingAllValues' to false.");
+            }
             if (arrayIndex > this.map.Count)
             {
                 throw
@@ -176,6 +197,13 @@ namespace Yaapii.Atoms.Lookup
         /// <returns>The enumerator</returns>
         public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
         {
+            if (this.rejectBuildingAllValues)
+            {
+                throw new InvalidOperationException(
+                    "Cannot get the enumerator because this is a lazy dictionary."
+                    + " Enumerating the entries would build all values."
+                    + " If you need this behaviour, set the ctor param 'rejectBuildingAllValues' to false.");
+            }
             return
                 new Enumerable.Mapped<KeyValuePair<string, Sticky<string>>, KeyValuePair<string, string>>(
                     kvp => new KeyValuePair<string, string>(kvp.Key, kvp.Value.Value()),
@@ -237,18 +265,26 @@ namespace Yaapii.Atoms.Lookup
     {
         private readonly IDictionary<string, Sticky<Value>> map;
         private readonly UnsupportedOperationException rejectReadException = new UnsupportedOperationException("Writing is not supported, it's a read-only map");
+        private readonly bool rejectBuildingAllValues;
 
         /// <summary>
         /// ctor
         /// </summary>
-        public LazyDict(params IKvp<Value>[] kvps) : this(new Many.Live<IKvp<Value>>(kvps))
+        public LazyDict(params IKvp<Value>[] kvps) : this(new Many.Live<IKvp<Value>>(kvps), true)
         { }
 
         /// <summary>
         /// ctor
         /// </summary>
-        public LazyDict(IEnumerable<IKvp<Value>> kvps)
+        public LazyDict(bool rejectBuildingAllValues, params IKvp<Value>[] kvps) : this(new Many.Live<IKvp<Value>>(kvps), rejectBuildingAllValues)
+        { }
+
+        /// <summary>
+        /// ctor
+        /// </summary>
+        public LazyDict(IEnumerable<IKvp<Value>> kvps, bool rejectBuildingAllValues = true)
         {
+            this.rejectBuildingAllValues = rejectBuildingAllValues;
             this.map =
                 new Map.Of<Sticky<Value>>(() =>
                 {
@@ -280,6 +316,13 @@ namespace Yaapii.Atoms.Lookup
         {
             get
             {
+                if (this.rejectBuildingAllValues)
+                {
+                    throw new InvalidOperationException(
+                        "Cannot get values because this is a lazy dictionary."
+                        + " Getting the values would build all keys."
+                        + " If you need this behaviour, set the ctor param 'rejectBuildingAllValues' to false.");
+                }
                 return
                     new List.Live<Value>(
                        new Enumerable.Mapped<Sticky<Value>, Value>(
@@ -354,6 +397,12 @@ namespace Yaapii.Atoms.Lookup
         /// <param name="arrayIndex">index to start</param>
         public void CopyTo(KeyValuePair<string, Value>[] array, int arrayIndex)
         {
+            if (this.rejectBuildingAllValues)
+            {
+                throw new InvalidOperationException("Cannot copy entries because this is a lazy dictionary."
+                    + " Copying the entries would build all values."
+                    + " If you need this behaviour, set the ctor param 'rejectBuildingAllValues' to false.");
+            }
             if (arrayIndex > this.map.Count)
             {
                 throw
@@ -374,6 +423,13 @@ namespace Yaapii.Atoms.Lookup
         /// <returns>The enumerator</returns>
         public IEnumerator<KeyValuePair<string, Value>> GetEnumerator()
         {
+            if (this.rejectBuildingAllValues)
+            {
+                throw new InvalidOperationException(
+                    "Cannot get the enumerator because this is a lazy dictionary."
+                    + " Enumerating the entries would build all values."
+                    + " If you need this behaviour, set the ctor param 'rejectBuildingAllValues' to false.");
+            }
             return
                 new Enumerable.Mapped<KeyValuePair<string, Sticky<Value>>, KeyValuePair<string, Value>>(
                     kvp => new KeyValuePair<string, Value>(kvp.Key, kvp.Value.Value()),
@@ -435,18 +491,26 @@ namespace Yaapii.Atoms.Lookup
     {
         private readonly IDictionary<Key, Sticky<Value>> map;
         private readonly UnsupportedOperationException rejectReadException = new UnsupportedOperationException("Writing is not supported, it's a read-only map");
+        private readonly bool rejectBuildingAllValues;
 
         /// <summary>
         /// ctor
         /// </summary>
-        public LazyDict(params IKvp<Key, Value>[] kvps) : this(new Many.Live<IKvp<Key, Value>>(kvps))
+        public LazyDict(params IKvp<Key, Value>[] kvps) : this(new Many.Of<IKvp<Key, Value>>(kvps), true)
         { }
 
         /// <summary>
         /// ctor
         /// </summary>
-        public LazyDict(IEnumerable<IKvp<Key, Value>> kvps)
+        public LazyDict(bool rejectBuildingAllValues, params IKvp<Key, Value>[] kvps) : this(new Many.Live<IKvp<Key, Value>>(kvps), rejectBuildingAllValues)
+        { }
+
+        /// <summary>
+        /// ctor
+        /// </summary>
+        public LazyDict(IEnumerable<IKvp<Key, Value>> kvps, bool rejectBuildingAllValues = true)
         {
+            this.rejectBuildingAllValues = rejectBuildingAllValues;
             this.map =
                 new Map.Of<Key, Sticky<Value>>(() =>
                 {
@@ -478,6 +542,13 @@ namespace Yaapii.Atoms.Lookup
         {
             get
             {
+                if (this.rejectBuildingAllValues)
+                {
+                    throw new InvalidOperationException(
+                        "Cannot get all values because this is a lazy dictionary."
+                        + " Getting the values would build all keys."
+                        + " If you need this behaviour, set the ctor param 'rejectBuildingAllValues' to false.");
+                }
                 return
                     new List.Live<Value>(
                        new Enumerable.Mapped<Sticky<Value>, Value>(
@@ -553,6 +624,13 @@ namespace Yaapii.Atoms.Lookup
         /// <param name="arrayIndex">index to start</param>
         public void CopyTo(KeyValuePair<Key, Value>[] array, int arrayIndex)
         {
+            if (this.rejectBuildingAllValues)
+            {
+                throw new InvalidOperationException(
+                    "Cannot copy entries because this is a lazy dictionary."
+                    + " Copying the entries would build all values."
+                    + " If you need this behaviour, set the ctor param 'rejectBuildingAllValues' to false.");
+            }
             if (arrayIndex > this.map.Count)
             {
                 throw
@@ -573,6 +651,13 @@ namespace Yaapii.Atoms.Lookup
         /// <returns>The enumerator</returns>
         public IEnumerator<KeyValuePair<Key, Value>> GetEnumerator()
         {
+            if (this.rejectBuildingAllValues)
+            {
+                throw new InvalidOperationException(
+                    "Cannot get the enumerator because this is a lazy dictionary."
+                    + " Enumerating the entries would build all values."
+                    + " If you need this behaviour, set the ctor param 'rejectBuildingAllValues' to false.");
+            }
             return
                 new Enumerable.Mapped<KeyValuePair<Key, Sticky<Value>>, KeyValuePair<Key, Value>>(
                     kvp => new KeyValuePair<Key, Value>(kvp.Key, kvp.Value.Value()),

--- a/src/Yaapii.Atoms/Map/LazyDict.cs
+++ b/src/Yaapii.Atoms/Map/LazyDict.cs
@@ -72,12 +72,12 @@ namespace Yaapii.Atoms.Lookup
             this.anyValueIsLazy = new Sticky<bool>(() =>
             {
                 return new Ternary<IFail, bool>(
-                    new LengthOf(kvps).Value() == 0,
-                    false,
+                    new ScalarOf<Boolean>(() => new LengthOf(kvps).Value() == 0),
+                    new False(),
                     new Reduced<bool>(
                         new Enumerable.Mapped<IKvp, bool>(kvp => kvp.IsLazy(), kvps),
                         (a, b) => a || b
-                    ).Value()
+                    )
                 ).Value();
             });
         }
@@ -311,12 +311,12 @@ namespace Yaapii.Atoms.Lookup
             this.anyValueIsLazy = new Sticky<bool>(() =>
             {
                 return new Ternary<IFail, bool>(
-                    new LengthOf(kvps).Value() == 0,
-                    false,
+                    new ScalarOf<Boolean>(() => new LengthOf(kvps).Value() == 0),
+                    new False(),
                     new Reduced<bool>(
                         new Enumerable.Mapped<IKvp<Value>, bool>(kvp => kvp.IsLazy(), kvps),
                         (a, b) => a || b
-                    ).Value()
+                    )
                 ).Value();
             });
         }
@@ -549,12 +549,12 @@ namespace Yaapii.Atoms.Lookup
             this.anyValueIsLazy = new Sticky<bool>(() =>
             {
                 return new Ternary<IFail, bool>(
-                    new LengthOf(kvps).Value() == 0,
-                    false,
+                    new ScalarOf<Boolean>(() => new LengthOf(kvps).Value() == 0),
+                    new False(),
                     new Reduced<bool>(
                         new Enumerable.Mapped<IKvp<Key, Value>, bool>(kvp => kvp.IsLazy(), kvps),
                         (a, b) => a || b
-                    ).Value()
+                    )
                 ).Value();
             });
 

--- a/src/Yaapii.Atoms/Map/LazyDict.cs
+++ b/src/Yaapii.Atoms/Map/LazyDict.cs
@@ -71,14 +71,15 @@ namespace Yaapii.Atoms.Lookup
                 });
             this.anyValueIsLazy = new Sticky<bool>(() =>
             {
-                return new Ternary<IFail, bool>(
-                    new ScalarOf<Boolean>(() => new LengthOf(kvps).Value() == 0),
-                    new False(),
-                    new Reduced<bool>(
-                        new Enumerable.Mapped<IKvp, bool>(kvp => kvp.IsLazy(), kvps),
-                        (a, b) => a || b
-                    )
-                ).Value();
+                bool result = false;
+                foreach (var kvp in kvps)
+                {
+                    if (kvp.IsLazy()) {
+                        result = true;
+                        break;
+                    }
+                }
+                return result;
             });
         }
 
@@ -310,14 +311,15 @@ namespace Yaapii.Atoms.Lookup
                 });
             this.anyValueIsLazy = new Sticky<bool>(() =>
             {
-                return new Ternary<IFail, bool>(
-                    new ScalarOf<Boolean>(() => new LengthOf(kvps).Value() == 0),
-                    new False(),
-                    new Reduced<bool>(
-                        new Enumerable.Mapped<IKvp<Value>, bool>(kvp => kvp.IsLazy(), kvps),
-                        (a, b) => a || b
-                    )
-                ).Value();
+                bool result = false;
+                foreach (var kvp in kvps)
+                {
+                    if (kvp.IsLazy()) {
+                        result = true;
+                        break;
+                    }
+                }
+                return result;
             });
         }
 
@@ -548,14 +550,15 @@ namespace Yaapii.Atoms.Lookup
                 });
             this.anyValueIsLazy = new Sticky<bool>(() =>
             {
-                return new Ternary<IFail, bool>(
-                    new ScalarOf<Boolean>(() => new LengthOf(kvps).Value() == 0),
-                    new False(),
-                    new Reduced<bool>(
-                        new Enumerable.Mapped<IKvp<Key, Value>, bool>(kvp => kvp.IsLazy(), kvps),
-                        (a, b) => a || b
-                    )
-                ).Value();
+                bool result = false;
+                foreach (var kvp in kvps)
+                {
+                    if (kvp.IsLazy()) {
+                        result = true;
+                        break;
+                    }
+                }
+                return result;
             });
 
         }

--- a/src/Yaapii.Atoms/Map/LazyDict.cs
+++ b/src/Yaapii.Atoms/Map/LazyDict.cs
@@ -188,7 +188,7 @@ namespace Yaapii.Atoms.Lookup
                         ).AsString());
             }
 
-            new List.Live<KeyValuePair<string, string>>(this).CopyTo(array, arrayIndex);
+            new List.Of<KeyValuePair<string, string>>(this).CopyTo(array, arrayIndex);
         }
 
         /// <summary>
@@ -414,7 +414,7 @@ namespace Yaapii.Atoms.Lookup
                         ).AsString());
             }
 
-            new List.Live<KeyValuePair<string, Value>>(this).CopyTo(array, arrayIndex);
+            new List.Of<KeyValuePair<string, Value>>(this).CopyTo(array, arrayIndex);
         }
 
         /// <summary>
@@ -642,7 +642,7 @@ namespace Yaapii.Atoms.Lookup
                         ).AsString());
             }
 
-            new List.Live<KeyValuePair<Key, Value>>(this).CopyTo(array, arrayIndex);
+            new List.Of<KeyValuePair<Key, Value>>(this).CopyTo(array, arrayIndex);
         }
 
         /// <summary>

--- a/tests/Yaapii.Atoms.Tests/Map/KvpOfTests.cs
+++ b/tests/Yaapii.Atoms.Tests/Map/KvpOfTests.cs
@@ -26,6 +26,18 @@ namespace Yaapii.Atoms.Lookup.Tests
         }
 
         [Fact]
+        public void KnowsAboutBeingLazy()
+        {
+            Assert.True(new Kvp.Of("2", () => "4").IsLazy());
+        }
+
+        [Fact]
+        public void KnowsAboutBeingNotLazy()
+        {
+            Assert.False(new Kvp.Of("2", "4").IsLazy());
+        }
+
+        [Fact]
         public void BuildsValueTyped()
         {
             Assert.Equal(
@@ -44,6 +56,18 @@ namespace Yaapii.Atoms.Lookup.Tests
         }
 
         [Fact]
+        public void KnowsAboutBeingLazyValue()
+        {
+            Assert.True(new Kvp.Of<int>("2", () => 4).IsLazy());
+        }
+
+        [Fact]
+        public void KnowsAboutBeingNotLazyValue()
+        {
+            Assert.False(new Kvp.Of<int>("2", 4).IsLazy());
+        }
+
+        [Fact]
         public void BuildsKeyValueTyped()
         {
             Assert.Equal(
@@ -59,6 +83,18 @@ namespace Yaapii.Atoms.Lookup.Tests
                 8,
                 new Kvp.Of<int, int>(8, () => throw new ApplicationException()).Key()
             );
+        }
+
+        [Fact]
+        public void KnowsAboutBeingLazyKeyValue()
+        {
+            Assert.True(new Kvp.Of<int, int>(2, () => 4).IsLazy());
+        }
+
+        [Fact]
+        public void KnowsAboutBeingNotLazyKeyValue()
+        {
+            Assert.False(new Kvp.Of<int, int>(2, 4).IsLazy());
         }
     }
 }

--- a/tests/Yaapii.Atoms.Tests/Map/LazyDictTests.cs
+++ b/tests/Yaapii.Atoms.Tests/Map/LazyDictTests.cs
@@ -11,7 +11,7 @@ namespace Yaapii.Atoms.Lookup.Tests
         public void AllValuesAreBuiltWhenPreventionIsDisabled()
         {
             var dict = new LazyDict<int, int>(false,
-                new FailingValueKvp(1, true)
+                new FkKvp<int, int>(() => 1, () => throw new Exception("i shall not be called"), () => true)
             );
 
             var ex = Assert.Throws<Exception>(() => new List<KeyValuePair<int, int>>(dict));
@@ -22,7 +22,7 @@ namespace Yaapii.Atoms.Lookup.Tests
         public void ValuesAreNotBuiltWhenLazy()
         {
             var dict = new LazyDict<int, int>(true,
-                new FailingValueKvp(1, true)
+                new FkKvp<int, int>(() => 1, () => throw new Exception("i shall not be called"), () => true)
             );
 
             var ex = Assert.Throws<InvalidOperationException>(() => dict.GetEnumerator());
@@ -33,7 +33,7 @@ namespace Yaapii.Atoms.Lookup.Tests
         public void ValuesAreBuiltWhenRejectionEnabledButValuesNotLazy()
         {
             var dict = new LazyDict<int, int>(true,
-               new FailingValueKvp(1, false)
+               new FkKvp<int, int>(() => 1, () => throw new Exception("i shall not be called"), () => false)
            );
 
             var ex = Assert.Throws<Exception>(() => new List<KeyValuePair<int, int>>(dict));
@@ -45,39 +45,6 @@ namespace Yaapii.Atoms.Lookup.Tests
         {
             var dict = new LazyDict<int, int>(true);
             dict.GetEnumerator();
-        }
-
-        /// <summary>
-        /// IKvp<int, int> with an always failing Value()
-        /// </summary>
-        private sealed class FailingValueKvp : IKvp<int, int>
-        {
-            private readonly int key;
-            private readonly bool isLazy;
-
-            /// <summary>
-            /// IKvp<int, int> with an always failing Value()
-            /// </summary>
-            public FailingValueKvp(int key, bool isLazy)
-            {
-                this.key = key;
-                this.isLazy = isLazy;
-            }
-
-            public int Value()
-            {
-                throw new Exception("i shall not be called");
-            }
-
-            public int Key()
-            {
-                return key;
-            }
-
-            public bool IsLazy()
-            {
-                return isLazy;
-            }
         }
     }
 }

--- a/tests/Yaapii.Atoms.Tests/Map/LazyDictTests.cs
+++ b/tests/Yaapii.Atoms.Tests/Map/LazyDictTests.cs
@@ -8,10 +8,10 @@ namespace Yaapii.Atoms.Lookup.Tests
     public sealed class LazyDictTests
     {
         [Fact]
-        public void ValuesAreBuilt()
+        public void AllValuesAreBuiltWhenPreventionIsDisabled()
         {
             var dict = new LazyDict<int, int>(false,
-                new FailingValueKvp(1)
+                new FailingValueKvp(1, true)
             );
 
             var ex = Assert.Throws<Exception>(() => new List<KeyValuePair<int, int>>(dict));
@@ -19,14 +19,32 @@ namespace Yaapii.Atoms.Lookup.Tests
         }
 
         [Fact]
-        public void ValuesAreNotBuilt()
+        public void ValuesAreNotBuiltWhenLazy()
         {
             var dict = new LazyDict<int, int>(true,
-                new FailingValueKvp(1)
+                new FailingValueKvp(1, true)
             );
 
             var ex = Assert.Throws<InvalidOperationException>(() => dict.GetEnumerator());
             Assert.Equal("Cannot get the enumerator because this is a lazy dictionary. Enumerating the entries would build all values. If you need this behaviour, set the ctor param 'rejectBuildingAllValues' to false.", ex.Message);
+        }
+
+        [Fact]
+        public void ValuesAreBuiltWhenRejectionEnabledButValuesNotLazy()
+        {
+            var dict = new LazyDict<int, int>(true,
+               new FailingValueKvp(1, false)
+           );
+
+            var ex = Assert.Throws<Exception>(() => new List<KeyValuePair<int, int>>(dict));
+            Assert.Equal("i shall not be called", ex.Message);
+        }
+
+        [Fact]
+        public void CanGetEnumeratorWhenEmpty()
+        {
+            var dict = new LazyDict<int, int>(true);
+            dict.GetEnumerator();
         }
 
         /// <summary>
@@ -35,13 +53,15 @@ namespace Yaapii.Atoms.Lookup.Tests
         private sealed class FailingValueKvp : IKvp<int, int>
         {
             private readonly int key;
+            private readonly bool isLazy;
 
             /// <summary>
             /// IKvp<int, int> with an always failing Value()
             /// </summary>
-            public FailingValueKvp(int key)
+            public FailingValueKvp(int key, bool isLazy)
             {
                 this.key = key;
+                this.isLazy = isLazy;
             }
 
             public int Value()
@@ -56,7 +76,7 @@ namespace Yaapii.Atoms.Lookup.Tests
 
             public bool IsLazy()
             {
-                return true;
+                return isLazy;
             }
         }
     }

--- a/tests/Yaapii.Atoms.Tests/Map/LazyDictTests.cs
+++ b/tests/Yaapii.Atoms.Tests/Map/LazyDictTests.cs
@@ -53,6 +53,11 @@ namespace Yaapii.Atoms.Lookup.Tests
             {
                 return key;
             }
+
+            public bool IsLazy()
+            {
+                return true;
+            }
         }
     }
 }

--- a/tests/Yaapii.Atoms.Tests/Map/LazyDictTests.cs
+++ b/tests/Yaapii.Atoms.Tests/Map/LazyDictTests.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Yaapii.Atoms.Lookup.Tests
+{
+    public sealed class LazyDictTests
+    {
+        [Fact]
+        public void ValuesAreBuilt()
+        {
+            var dict = new LazyDict<int, int>(false,
+                new FailingValueKvp(1)
+            );
+
+            var ex = Assert.Throws<Exception>(() => new List<KeyValuePair<int, int>>(dict));
+            Assert.Equal("i shall not be called", ex.Message);
+        }
+
+        [Fact]
+        public void ValuesAreNotBuilt()
+        {
+            var dict = new LazyDict<int, int>(true,
+                new FailingValueKvp(1)
+            );
+
+            var ex = Assert.Throws<InvalidOperationException>(() => dict.GetEnumerator());
+            Assert.Equal("Cannot get the enumerator because this is a lazy dictionary. Enumerating the entries would build all values. If you need this behaviour, set the ctor param 'rejectBuildingAllValues' to false.", ex.Message);
+        }
+
+        /// <summary>
+        /// IKvp<int, int> with an always failing Value()
+        /// </summary>
+        private sealed class FailingValueKvp : IKvp<int, int>
+        {
+            private readonly int key;
+
+            /// <summary>
+            /// IKvp<int, int> with an always failing Value()
+            /// </summary>
+            public FailingValueKvp(int key)
+            {
+                this.key = key;
+            }
+
+            public int Value()
+            {
+                throw new Exception("i shall not be called");
+            }
+
+            public int Key()
+            {
+                return key;
+            }
+        }
+    }
+}

--- a/tests/Yaapii.Atoms.Tests/Map/SortedTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Map/SortedTest.cs
@@ -80,7 +80,7 @@ namespace Yaapii.Atoms.Lookup.Tests
         [InlineData(0, -5)]
         [InlineData(1, 1)]
         [InlineData(2, 6)]
-        public void DoesNotBuildValueWhenNotNeeded(int index, int expectedKey)
+        public void EnumeratesKeysWhenLazy(int index, int expectedKey)
         {
             var unsorted = new LazyDict<int, int>(false,
                 new Kvp.Of<int, int>(1, () => { throw new Exception("i shall not be called"); }),

--- a/tests/Yaapii.Atoms.Tests/Map/SortedTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Map/SortedTest.cs
@@ -106,7 +106,7 @@ namespace Yaapii.Atoms.Lookup.Tests
         }
 
         [Fact]
-        public void BuildingAllValuesThrowsWithEnabledBuildAllRejection()
+        public void RejectsBuildingAllValuesByDefault()
         {
             var unsorted = new LazyDict<int, int>(false,
                 new Kvp.Of<int, int>(1, () => 4),

--- a/tests/Yaapii.Atoms.Tests/Map/SortedTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Map/SortedTest.cs
@@ -89,8 +89,8 @@ namespace Yaapii.Atoms.Lookup.Tests
         [Fact]
         public void DoesNotBuildValueWhenNotNeeded()
         {
-            var unsorted = new LazyDict<int, int>(
-                new Kvp.Of<int, int>(1, () => { throw new Exception("i shall not be called"); }),
+            var unsorted = new LazyDict<int, int>(false,
+                new Kvp.Of<int, int>(1, () => 4),
                 new Kvp.Of<int, int>(6, () => { throw new Exception("i shall not be called"); }),
                 new Kvp.Of<int, int>(-5, () => { throw new Exception("i shall not be called"); })
             );
@@ -104,8 +104,12 @@ namespace Yaapii.Atoms.Lookup.Tests
             Assert.Equal(1, keys[1]);
             Assert.Equal(6, keys[2]);
 
-            var ex = Assert.Throws<Exception>(() => sorted.Values.GetEnumerator());
-            Assert.Equal("i shall not be called", ex.Message);
+            // Sanety check: building one value isn't a problem
+            Assert.Equal(4, sorted[1]);
+
+            // Sanety check: but all of them is
+            var ex = Assert.Throws<InvalidOperationException>(() => sorted.Values.GetEnumerator());
+            Assert.Equal("Cannot get all values because this is a lazy dictionary. Getting the values would build all keys. If you need this behaviour, set the ctor param 'rejectBuildingAllValues' to false.", ex.Message);
         }
     }
 }

--- a/tests/Yaapii.Atoms.Tests/Map/SortedTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Map/SortedTest.cs
@@ -94,7 +94,7 @@ namespace Yaapii.Atoms.Lookup.Tests
         }
 
         [Fact]
-        public void BuildingSingleValueIsStillOkWithBuildAllRejection()
+        public void DeliversSingleValueWhenLazy()
         {
             var unsorted = new LazyDict<int, int>(false,
                 new Kvp.Of<int, int>(1, () => 4),

--- a/tests/Yaapii.Atoms.Tests/Map/SortedTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Map/SortedTest.cs
@@ -19,7 +19,6 @@ namespace Yaapii.Atoms.Lookup.Tests
                 {6, 3 },
                 {-5, 2}
             };
-
             Assert.Equal(expectedValue, unsorted[key]);
             var sorted = new Sorted<int, int>(unsorted);
             Assert.Equal(expectedValue, sorted[key]);
@@ -37,13 +36,15 @@ namespace Yaapii.Atoms.Lookup.Tests
                 new KeyValuePair<int, int>(6, 3),
                 new KeyValuePair<int, int>(-5, 2)
             };
-
             var sorted = new Sorted<int, int>(unsorted);
             Assert.Equal(expectedValue, sorted[key]);
         }
 
-        [Fact]
-        public void SortsByFunction()
+        [Theory]
+        [InlineData(0, -5)]
+        [InlineData(1, 6)]
+        [InlineData(2, 1)]
+        public void SortsByFunction(int index, int expectedKey)
         {
             var unsorted = new Dictionary<int, int>()
             {
@@ -51,23 +52,17 @@ namespace Yaapii.Atoms.Lookup.Tests
                 {6, 3 },
                 {-5, 2}
             };
-
             var sorted = new Sorted<int, int>(unsorted, (a, b) => a.Value - b.Value);
-
             var sortedArr = new KeyValuePair<int, int>[3];
             sorted.CopyTo(sortedArr, 0);
-
-            Assert.Equal(2, sortedArr[0].Value);
-            Assert.Equal(3, sortedArr[1].Value);
-            Assert.Equal(4, sortedArr[2].Value);
-
-            Assert.Equal(-5, sortedArr[0].Key);
-            Assert.Equal(6, sortedArr[1].Key);
-            Assert.Equal(1, sortedArr[2].Key);
+            Assert.Equal(expectedKey, sortedArr[index].Key);
         }
 
-        [Fact]
-        public void DefaultComparerSeemsSane()
+        [Theory]
+        [InlineData(0, -5)]
+        [InlineData(1, 1)]
+        [InlineData(2, 6)]
+        public void DefaultComparerSeemsSane(int index, int expectedKey)
         {
             var unsorted = new Dictionary<int, int>()
             {
@@ -75,39 +70,50 @@ namespace Yaapii.Atoms.Lookup.Tests
                 {6, 3 },
                 {-5, 2}
             };
-
             var sorted = new Sorted<int, int>(unsorted);
-
             var keys = new int[3];
             sorted.Keys.CopyTo(keys, 0);
+            Assert.Equal(expectedKey, keys[index]);
+        }
 
-            Assert.Equal(-5, keys[0]);
-            Assert.Equal(1, keys[1]);
-            Assert.Equal(6, keys[2]);
+        [Theory]
+        [InlineData(0, -5)]
+        [InlineData(1, 1)]
+        [InlineData(2, 6)]
+        public void DoesNotBuildValueWhenNotNeeded(int index, int expectedKey)
+        {
+            var unsorted = new LazyDict<int, int>(false,
+                new Kvp.Of<int, int>(1, () => { throw new Exception("i shall not be called"); }),
+                new Kvp.Of<int, int>(6, () => { throw new Exception("i shall not be called"); }),
+                new Kvp.Of<int, int>(-5, () => { throw new Exception("i shall not be called"); })
+            );
+            var sorted = new Sorted<int, int>(unsorted);
+            var keys = new int[3];
+            sorted.Keys.CopyTo(keys, 0);
+            Assert.Equal(expectedKey, keys[index]);
         }
 
         [Fact]
-        public void DoesNotBuildValueWhenNotNeeded()
+        public void BuildingSingleValueIsStillOkWithBuildAllRejection()
         {
             var unsorted = new LazyDict<int, int>(false,
                 new Kvp.Of<int, int>(1, () => 4),
                 new Kvp.Of<int, int>(6, () => { throw new Exception("i shall not be called"); }),
                 new Kvp.Of<int, int>(-5, () => { throw new Exception("i shall not be called"); })
             );
-
             var sorted = new Sorted<int, int>(unsorted);
-
-            var keys = new int[3];
-            sorted.Keys.CopyTo(keys, 0);
-
-            Assert.Equal(-5, keys[0]);
-            Assert.Equal(1, keys[1]);
-            Assert.Equal(6, keys[2]);
-
-            // Sanety check: building one value isn't a problem
             Assert.Equal(4, sorted[1]);
+        }
 
-            // Sanety check: but all of them is
+        [Fact]
+        public void BuildingAllValuesThrowsWithEnabledBuildAllRejection()
+        {
+            var unsorted = new LazyDict<int, int>(false,
+                new Kvp.Of<int, int>(1, () => 4),
+                new Kvp.Of<int, int>(6, () => { throw new Exception("i shall not be called"); }),
+                new Kvp.Of<int, int>(-5, () => { throw new Exception("i shall not be called"); })
+            );
+            var sorted = new Sorted<int, int>(unsorted);
             var ex = Assert.Throws<InvalidOperationException>(() => sorted.Values.GetEnumerator());
             Assert.Equal("Cannot get all values because this is a lazy dictionary. Getting the values would build all keys. If you need this behaviour, set the ctor param 'rejectBuildingAllValues' to false.", ex.Message);
         }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
<!-- Describe the current behavior or link to a open issue -->
closes #375
closes #377

### What is the new behavior?
<!-- Describe the new behavior -->

### Does this PR introduce a breaking change? (check one with "x")
- [x] Yes
- [ ] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications

The LazyMap does not build all the elements anymore with the same arguments. `rejectBuildingAllValues` has to be set to false in order to use it like before.