### PR TITLE
Fix Union ctor to make compare function usable

### DIFF
--- a/src/Yaapii.Atoms/Enumerable/Union.cs
+++ b/src/Yaapii.Atoms/Enumerable/Union.cs
@@ -33,14 +33,16 @@ namespace Yaapii.Atoms.Enumerable
         /// <summary>
         /// Union objects in two enumerables.
         /// </summary>
-        public Union(IEnumerable<T> a, IEnumerable<T> b, Func<T, bool> compare) : base(() =>
+        /// <param name="compare">Decission to put items from a in the resulting union</param>
+        public Union(IEnumerable<T> a, IEnumerable<T> b, Func<T, T, bool> compare) : base(() =>
             {
                 var result = new List<T>();
-                foreach (var item in b)
+                foreach (var aItem in a)
                 {
-                    if (new Contains<T>(a, compare).Value())
+
+                    if (new Contains<T>(b, bItem => compare.Invoke(aItem, bItem)).Value())
                     {
-                        result.Add(item);
+                        result.Add(aItem);
                     }
                 }
                 return result;

--- a/src/Yaapii.Atoms/Enumerable/Union.cs
+++ b/src/Yaapii.Atoms/Enumerable/Union.cs
@@ -39,7 +39,6 @@ namespace Yaapii.Atoms.Enumerable
                 var result = new List<T>();
                 foreach (var aItem in a)
                 {
-
                     if (new Contains<T>(b, bItem => compare.Invoke(aItem, bItem)).Value())
                     {
                         result.Add(aItem);

--- a/tests/Yaapii.Atoms.Tests/Enumerable/UnionTests.cs
+++ b/tests/Yaapii.Atoms.Tests/Enumerable/UnionTests.cs
@@ -21,7 +21,10 @@
 // SOFTWARE.
 
 using System.Collections.Generic;
+using System.IO;
 using Xunit;
+using Yaapii.Atoms.List;
+using Yaapii.Atoms.Scalar;
 
 namespace Yaapii.Atoms.Enumerable.Tests
 {
@@ -60,6 +63,27 @@ namespace Yaapii.Atoms.Enumerable.Tests
                 expected,
                 new Union<int>(
                    a, b
+                )
+            );
+        }
+
+        [Fact]
+        public void UsesCompareFunction()
+        {
+            var a = new ListOf<string>("c:/abraham/a.jpg", "c:/bertram/b.jpg", "c:/caesar/c.jpg");
+            var b = new ListOf<string>("a", "c");
+            var expected = new ListOf<string>("c:/abraham/a.jpg", "c:/caesar/c.jpg");
+
+            Assert.Equal(
+                expected,
+                new Union<string>(
+                    a,
+                    b,
+                    (aItem, bItem) =>
+                        new Equals<string>(
+                            Path.GetFileNameWithoutExtension(aItem),
+                            bItem
+                        ).Value()
                 )
             );
         }

--- a/tests/Yaapii.Atoms.Tests/Enumerable/UnionTests.cs
+++ b/tests/Yaapii.Atoms.Tests/Enumerable/UnionTests.cs
@@ -70,15 +70,11 @@ namespace Yaapii.Atoms.Enumerable.Tests
         [Fact]
         public void UsesCompareFunction()
         {
-            var a = new ListOf<string>("c:/abraham/a.jpg", "c:/bertram/b.jpg", "c:/caesar/c.jpg");
-            var b = new ListOf<string>("a", "c");
-            var expected = new ListOf<string>("c:/abraham/a.jpg", "c:/caesar/c.jpg");
-
             Assert.Equal(
-                expected,
+                new ListOf<string>("c:/abraham/a.jpg", "c:/caesar/c.jpg"),
                 new Union<string>(
-                    a,
-                    b,
+                    new ListOf<string>("c:/abraham/a.jpg", "c:/bertram/b.jpg", "c:/caesar/c.jpg"),
+                    new ListOf<string>("a", "c"),
                     (aItem, bItem) =>
                         new Equals<string>(
                             Path.GetFileNameWithoutExtension(aItem),


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
<!-- Describe the current behavior or link to a open issue -->
closes #427 

### What is the new behavior?
<!-- Describe the new behavior -->
Union with compare function: `Union(IEnumerable<T> a, IEnumerable<T> b, Func<T, T, bool> compare)`

### Does this PR introduce a breaking change? (check one with "x")
- [x] Yes
- [ ] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications
Change ctor from
`Union(IEnumerable<T> a, IEnumerable<T> b, Func<T, bool> compare)`
to
`Union(IEnumerable<T> a, IEnumerable<T> b, Func<T, T, bool> compare)`
###  Other information
I can't imagine any use case for the refactored ctor `Union(IEnumerable<T> a, IEnumerable<T> b, Func<T, bool> compare)`.
If there is any I can undo deleting this and thus remove the breaking change.
What do you think?