### PR TITLE
fix: make enumerables sticky

### DIFF
--- a/src/Yaapii.Atoms/Collection/Filtered.cs
+++ b/src/Yaapii.Atoms/Collection/Filtered.cs
@@ -43,16 +43,14 @@ namespace Yaapii.Atoms.Collection
         public Filtered(Func<T, Boolean> func, T item1, T item2, params T[] items) :
             this(
                 func,
-                new LiveMany<T>(
-                    new Live<IEnumerator<T>>(
-                        () => new Enumerable.Joined<T>(
-                            new LiveMany<T>(
-                                item1,
-                                item2
-                            ),
-                            items
-                        ).GetEnumerator()
-                    )
+                new LiveMany<T>(() => 
+                    new Enumerable.Joined<T>(
+                        new ManyOf<T>(
+                            item1,
+                            item2
+                        ),
+                        items
+                    ).GetEnumerator()
                 )
             )
         { }

--- a/src/Yaapii.Atoms/Collection/Sorted.cs
+++ b/src/Yaapii.Atoms/Collection/Sorted.cs
@@ -22,7 +22,7 @@
 
 using System;
 using System.Collections.Generic;
-using Yaapii.Atoms.Enumerator;
+using Yaapii.Atoms.Enumerable;
 using Yaapii.Atoms.List;
 
 namespace Yaapii.Atoms.Collection
@@ -38,7 +38,7 @@ namespace Yaapii.Atoms.Collection
         /// A list with default sorting (ascending)
         /// </summary>
         /// <param name="src">the source enumerable</param>
-        public Sorted(params T[] src) : this(new LiveList<T>(src))
+        public Sorted(params T[] src) : this(new LiveMany<T>(src))
         { }
 
         /// <summary>

--- a/src/Yaapii.Atoms/Enumerable/Filtered.cs
+++ b/src/Yaapii.Atoms/Enumerable/Filtered.cs
@@ -44,14 +44,12 @@ namespace Yaapii.Atoms.Enumerable
         /// <param name="items">other items to filter</param>
         public Filtered(Func<T, Boolean> fnc, T item1, T item2, params T[] items) : this(
             fnc,
-            new LiveMany<T>(() => 
-                new Joined<T>(
-                    new LiveMany<T>(
-                        item1,
-                        item2
-                    ),
-                    items
-                ).GetEnumerator()
+            new Joined<T>(
+                new LiveMany<T>(
+                    item1,
+                    item2
+                ),
+                items
             )
         )
         { }
@@ -62,11 +60,9 @@ namespace Yaapii.Atoms.Enumerable
         /// <param name="src">enumerable to filter</param>
         /// <param name="fnc">filter function</param>
         public Filtered(Func<T, Boolean> fnc, IEnumerable<T> src) : base(() =>
-            new LiveMany<T>(() =>
-                new Enumerator.Filtered<T>(
-                    src.GetEnumerator(),
-                    fnc
-                )
+            new Enumerator.Filtered<T>(
+                src.GetEnumerator(),
+                fnc
             ),
             false
         )

--- a/src/Yaapii.Atoms/Enumerable/Joined.cs
+++ b/src/Yaapii.Atoms/Enumerable/Joined.cs
@@ -39,16 +39,82 @@ namespace Yaapii.Atoms.Enumerable
         /// </summary>
         /// <param name="lst">enumerable of items to join</param>
         /// <param name="items">array of items to join</param>
-        public Joined(IEnumerable<T> lst, params T[] items) : this(
-            new LiveMany<IEnumerable<T>>(lst, new LiveMany<T>(items)))
+        public Joined(T first, T second, IEnumerable<T> lst, params T[] items) : base(() =>
+        {
+            int idx = 2;
+            T[] joined = new T[1 + new LengthOf(lst).Value() + items.Length];
+            joined[0] = first;
+            joined[1] = second;
+            var enm = lst.GetEnumerator();
+            while (enm.MoveNext())
+            {
+                joined[idx] = enm.Current;
+                idx++;
+            }
+
+            foreach (var item in items)
+            {
+                joined[idx] = item;
+                idx++;
+            }
+            return new ManyOf<T>(joined);
+        },
+            false
+        )
         { }
 
         /// <summary>
-        /// Multiple <see cref="IEnumerable{T}"/> joined together.
+        /// Join a <see cref="IEnumerable{T}"/> with (multiple) single Elements.
         /// </summary>
-        /// <param name="items">enumerables to join</param>
-        public Joined(params IEnumerable<T>[] items) : this(
-            new LiveMany<IEnumerable<T>>(items)
+        /// <param name="lst">enumerable of items to join</param>
+        /// <param name="items">array of items to join</param>
+        public Joined(T first, IEnumerable<T> lst, params T[] items) : base(() =>
+            {
+                int idx = 1;
+                T[] joined = new T[1 + new LengthOf(lst).Value() + items.Length];
+                joined[0] = first;
+                var enm = lst.GetEnumerator();
+                while (enm.MoveNext())
+                {
+                    joined[idx] = enm.Current;
+                    idx++;
+                }
+
+                foreach (var item in items)
+                {
+                    joined[idx] = item;
+                    idx++;
+                }
+                return new ManyOf<T>(joined);
+            },
+            false
+        )
+        { }
+
+        /// <summary>
+        /// Join a <see cref="IEnumerable{T}"/> with (multiple) single Elements.
+        /// </summary>
+        /// <param name="lst">enumerable of items to join</param>
+        /// <param name="items">array of items to join</param>
+        public Joined(IEnumerable<T> lst, params T[] items) : base(() =>
+            {
+                int idx = 0;
+                T[] joined = new T[new LengthOf(lst).Value() + items.Length];
+                var enm = lst.GetEnumerator();
+                while (enm.MoveNext())
+                {
+                    joined[idx] = enm.Current;
+                    idx++;
+                }
+
+                foreach (var item in items)
+                {
+                    joined[idx] = item;
+                    idx++;
+                }
+                return new ManyOf<T>(joined);
+            },
+            false
         )
         { }
 
@@ -56,7 +122,16 @@ namespace Yaapii.Atoms.Enumerable
         /// Multiple <see cref="IEnumerable{T}"/> joined together.
         /// </summary>
         /// <param name="items">enumerables to join</param>
-        public Joined(IEnumerable<IEnumerable<T>> items) : base(() => 
+        public Joined(params IEnumerable<T>[] items) : this(
+            new ManyOf<IEnumerable<T>>(items)
+        )
+        { }
+
+        /// <summary>
+        /// Multiple <see cref="IEnumerable{T}"/> joined together.
+        /// </summary>
+        /// <param name="items">enumerables to join</param>
+        public Joined(IEnumerable<IEnumerable<T>> items) : base(() =>
             new LiveMany<T>(() =>
                 new Enumerator.Joined<T>(
                     new Mapped<IEnumerable<T>, IEnumerator<T>>(//Map the content of list: Get every enumerator out of it and build one whole enumerator from it

--- a/src/Yaapii.Atoms/Enumerable/LiveMany.cs
+++ b/src/Yaapii.Atoms/Enumerable/LiveMany.cs
@@ -64,7 +64,7 @@ namespace Yaapii.Atoms.Enumerable
         /// A <see cref="IEnumerable{T}"/> out of a <see cref="IEnumerator{T}"/> encapsulated in a <see cref="IScalar{T}"/>"/>.
         /// </summary>
         /// <param name="origin">scalar to return the IEnumerator</param>
-        public LiveMany(IScalar<IEnumerator<T>> origin) : base(
+        private LiveMany(IScalar<IEnumerator<T>> origin) : base(
             new Live<IEnumerable<T>>(
                 () => new LiveEnumeratorAsEnumerable<T>(origin.Value())
             ),

--- a/src/Yaapii.Atoms/Enumerable/ManyOf.cs
+++ b/src/Yaapii.Atoms/Enumerable/ManyOf.cs
@@ -43,7 +43,7 @@ namespace Yaapii.Atoms.Enumerable
         public ManyOf(params string[] items) : this(() =>
             {
                 var lst = new List<string>();
-                for(int i=0;i<items.Length;i++)
+                for (int i = 0; i < items.Length; i++)
                 {
                     lst.Add(items[i]);
                 };
@@ -77,16 +77,7 @@ namespace Yaapii.Atoms.Enumerable
         /// </summary>
         /// <param name="origin">scalar to return the IEnumerator</param>
         public ManyOf(Func<IEnumerator<string>> origin) : base(
-            () =>
-            {
-                var enm = origin();
-                var lst = new List<string>();
-                while (enm.MoveNext())
-                {
-                    lst.Add(enm.Current);
-                };
-                return lst;
-            },
+            origin,
             false
         )
         { }
@@ -133,16 +124,7 @@ namespace Yaapii.Atoms.Enumerable
         /// </summary>
         /// <param name="origin">scalar to return the IEnumerator</param>
         public ManyOf(Func<IEnumerator<T>> origin) : base(
-            () =>
-            {
-                var enm = origin();
-                var lst = new List<T>();
-                while (enm.MoveNext())
-                {
-                    lst.Add(enm.Current);
-                };
-                return lst;
-            },
+            origin,
             false
         )
         { }

--- a/src/Yaapii.Atoms/Enumerator/Cached.cs
+++ b/src/Yaapii.Atoms/Enumerator/Cached.cs
@@ -1,0 +1,207 @@
+﻿// MIT License
+//
+// Copyright(c) 2020 ICARUS Consulting GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Yaapii.Atoms.Enumerable;
+using Yaapii.Atoms.Scalar;
+
+namespace Yaapii.Atoms.Enumerator
+{
+    /// <summary>
+    /// An enumerator which is sticky. 
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public sealed class Cached<T> : IEnumerator<T>
+    {
+        private readonly int[] position;
+        private readonly Cache<T> cache;
+
+        /// In order to allow enumerables to not pre-compute/copy all elements,
+        /// this ctor allows injecting and therefore re-using the caching elements.
+        /// An enumerable like <see cref="ManyEnvelope"/> can then issue multiple 
+        /// Enumerators while the same cache is filled when advancing them.
+        public Cached(Cache<T> cache)
+        {
+            this.position = new int[1] { -1 };
+            this.cache = cache;
+        }
+
+        public T Current
+        {
+            get
+            {
+                lock (this.position)
+                {
+                    if (this.position[0] == -1)
+                    {
+                        throw new InvalidOperationException("Cannot get current element - move the enumerator first.");
+                    }
+                    if (!this.cache.ContainsKey(this.position[0]))
+                    {
+                        throw new InvalidOperationException("Cannot get element - the enumerable does not have that much elements.");
+                    }
+                    return this.cache[this.position[0]];
+                }
+            }
+        }
+
+        object IEnumerator.Current => this.Current;
+
+        public bool MoveNext()
+        {
+            bool moved = false;
+            lock (this.position)
+            {
+                var next = this.position[0] + 1;
+                if (this.cache.ContainsKey(next))
+                {
+                    this.position[0] = next;
+                    moved = true;
+                }
+            }
+            return moved;
+        }
+
+        public void Reset()
+        {
+            this.position[0] = -1;
+        }
+
+        public void Dispose()
+        {
+        }
+
+        /// <summary>
+        /// A cache for the enumerator, realized as map.
+        /// When asking for a key, the enumerator will be advanced until the 
+        /// position, if existing, is found.
+        /// All values which are visited will be cached.
+        /// </summary>
+        public sealed class Cache<T> : IDictionary<int, T>
+        {
+            private readonly IScalar<IEnumerator<T>> origin;
+            private readonly List<T> cache;
+            private readonly bool[] reachedEnd;
+            private readonly int[] count;
+
+            public Cache(Func<IEnumerator<T>> origin)
+            {
+                this.count = new int[1] { 0 };
+                this.reachedEnd = new bool[1] { false };
+                this.origin = new ScalarOf<IEnumerator<T>>(origin);
+                this.cache = new List<T>();
+            }
+
+            public bool ContainsKey(int key)
+            {
+                while (this.cache.Count < key + 1 && !this.reachedEnd[0])
+                {
+                    lock (origin)
+                    {
+                        if (!this.reachedEnd[0])
+                        {
+                            var moved = origin.Value().MoveNext();
+                            if (moved)
+                            {
+                                this.cache.Add(origin.Value().Current);
+                            }
+                            else
+                            {
+                                this.reachedEnd[0] = true;
+                                break;
+                            }
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+                }
+                return this.cache.Count > key;
+            }
+
+            public T this[int key]
+            {
+                get
+                {
+                    if (this.ContainsKey(key))
+                    {
+                        return this.cache[key];
+                    }
+                    else
+                    {
+                        throw new ArgumentException($"Cannot get value number {key} the origin enumerator did only have {this.cache.Count} elements.");
+                    }
+                }
+                set
+                {
+                    throw new InvalidOperationException("Setting a value is not supported.");
+                }
+            }
+
+            public ICollection<int> Keys => throw new InvalidOperationException("Enumerating keys is not supported.");
+
+            public ICollection<T> Values => throw new InvalidOperationException("Enumerating values is not supported.");
+
+            public int Count
+            {
+                get
+                {
+                    var count = 0;
+                    if (!this.reachedEnd[0])
+                    {
+                        while (this.ContainsKey(count))
+                        {
+                            count++;
+                            this.count[0] = count;
+                        }
+                    }
+                    return this.count[0];
+                }
+            }
+
+            public bool IsReadOnly => true;
+
+            public void Add(int key, T value) => throw new InvalidOperationException("Adding values is not supported.");
+
+            public void Add(KeyValuePair<int, T> item) => throw new InvalidOperationException("Adding values is not supported.");
+
+            public void Clear() => throw new InvalidOperationException("Clearing is not supported.");
+
+            public bool Contains(KeyValuePair<int, T> item) => throw new InvalidOperationException("Testing contained items is not supported.");
+
+            public void CopyTo(KeyValuePair<int, T>[] array, int arrayIndex) => throw new InvalidOperationException("Copying this map is not supported.");
+
+            public IEnumerator<KeyValuePair<int, T>> GetEnumerator() => throw new InvalidOperationException("Getting the enumerator is not supported.");
+
+            public bool Remove(int key) => throw new InvalidOperationException("Removing elements is not supported.");
+
+            public bool Remove(KeyValuePair<int, T> item) => throw new InvalidOperationException("Removing elements is not supported.");
+
+            public bool TryGetValue(int key, out T value) => throw new InvalidOperationException("Trying to get values is not supported.");
+
+            IEnumerator IEnumerable.GetEnumerator() => throw new InvalidOperationException("Getting the enumerator is not supported.");
+        }
+    }
+}

--- a/src/Yaapii.Atoms/Enumerator/Filtered.cs
+++ b/src/Yaapii.Atoms/Enumerator/Filtered.cs
@@ -23,10 +23,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Text;
-using Yaapii.Atoms.Fail;
-using Yaapii.Atoms.Error;
-using Yaapii.Atoms.Func;
 
 #pragma warning disable NoProperties // No Properties
 #pragma warning disable CS1591

--- a/src/Yaapii.Atoms/Lists/Joined.cs
+++ b/src/Yaapii.Atoms/Lists/Joined.cs
@@ -20,10 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Yaapii.Atoms.Enumerable;
-using Yaapii.Atoms.Scalar;
 
 namespace Yaapii.Atoms.List
 {
@@ -40,7 +38,9 @@ namespace Yaapii.Atoms.List
         /// <param name="src">lists to join</param>
         public Joined(IList<T> origin, params IList<T>[] src) : this(
             new Enumerable.Joined<IList<T>>(
-                new ManyOf<IList<T>>(origin), src))
+                new LiveMany<IList<T>>(origin), src
+            )
+        )
         { }
 
         /// <summary>
@@ -50,14 +50,14 @@ namespace Yaapii.Atoms.List
         /// <param name="origin">a list to join</param>
         public Joined(IList<T> origin, params T[] src) : this(
             new Enumerable.Joined<IList<T>>(
-                new ManyOf<IList<T>>(origin), src))
+                new LiveMany<IList<T>>(origin), src))
         { }
 
         /// <summary>
         /// ctor
         /// </summary>
         /// <param name="src">The lists to join together</param>
-        public Joined(params IList<T>[] src) : this(new ManyOf<IList<T>>(src))
+        public Joined(params IList<T>[] src) : this(new LiveMany<IList<T>>(src))
         { }
 
         /// <summary>
@@ -66,13 +66,10 @@ namespace Yaapii.Atoms.List
         /// <param name="src">The lists to join together</param>
         public Joined(IEnumerable<IList<T>> src) : base(() =>
             {
-                var blocking = new BlockingCollection<T>();
-                foreach (var lst in src)
-                {
-                    new Each<T>(item => blocking.Add(item), lst).Invoke();
-                }
-
-                return new LiveList<T>(blocking);
+                return 
+                    new ListOf<T>(
+                        new Atoms.Enumerable.Joined<T>(src)
+                    );
             },
             false
         )

--- a/src/Yaapii.Atoms/Lists/ListOf.cs
+++ b/src/Yaapii.Atoms/Lists/ListOf.cs
@@ -35,7 +35,7 @@ namespace Yaapii.Atoms.List
         /// ctor
         /// </summary>
         /// <param name="array">source array</param>
-        public ListOf(params T[] array) : this(new LiveMany<T>(array))
+        public ListOf(params T[] array) : this(new ManyOf<T>(array))
         { }
 
         /// <summary>

--- a/src/Yaapii.Atoms/Lists/LiveList.cs
+++ b/src/Yaapii.Atoms/Lists/LiveList.cs
@@ -20,8 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System;
 using System.Collections.Generic;
-using Yaapii.Atoms.Enumerable;
 
 namespace Yaapii.Atoms.List
 {
@@ -34,23 +34,9 @@ namespace Yaapii.Atoms.List
         /// <summary>
         /// ctor
         /// </summary>
-        /// <param name="array">source array</param>
-        public LiveList(params T[] array) : this(new LiveMany<T>(array))
-        { }
-
-        /// <summary>
-        /// ctor
-        /// </summary>
-        /// <param name="src">source enumerator</param>
-        public LiveList(IEnumerator<T> src) : this(new LiveMany<T>(() => src))
-        { }
-
-        /// <summary>
-        /// ctor
-        /// </summary>
         /// <param name="src">source enumerable</param>
-        public LiveList(IEnumerable<T> src) : base(
-            () => new List<T>(src),
+        public LiveList(Func<IList<T>> src) : base(
+            src,
             true
         )
         { }

--- a/src/Yaapii.Atoms/Lists/Mapped.cs
+++ b/src/Yaapii.Atoms/Lists/Mapped.cs
@@ -35,40 +35,55 @@ namespace Yaapii.Atoms.List
         /// <summary>
         /// ctor
         /// </summary>
-        /// <param name="fnc">mapping function</param>
+        /// <param name="mapping">mapping function</param>
         /// <param name="src">source enumerator</param>
-        public Mapped(IFunc<In, Out> fnc, IEnumerable<In> src) : this((input)=>fnc.Invoke(input), src)
+        public Mapped(IFunc<In, Out> mapping, IEnumerable<In> src) : this((input) => mapping.Invoke(input), src)
         { }
 
         /// <summary>
         /// ctor
         /// </summary>
-        /// <param name="fnc">mapping function</param>
+        /// <param name="mapping">mapping function</param>
         /// <param name="src">source enumerator</param>
-        public Mapped(Func<In, Out> fnc, IEnumerator<In> src) : this(fnc, new LiveList<In>(src))
+        public Mapped(Func<In, Out> mapping, IEnumerator<In> src) : base(() =>
+            new LiveList<Out>(() =>
+            {
+                var result = new List<Out>();
+                while(src.MoveNext())
+                {
+                    result.Add(mapping.Invoke(src.Current));
+                }
+                return result;
+            }),
+            false
+        )
         { }
 
         /// <summary>
         /// ctor
         /// </summary>
-        /// <param name="fnc">mapping function</param>
+        /// <param name="mapping">mapping function</param>
         /// <param name="src">source enumerator</param>
-        public Mapped(Func<In, Out> fnc, IEnumerable<In> src) : this(fnc, new LiveList<In>(src))
-        { }
-
-        /// <summary>
-        /// ctor
-        /// </summary>
-        /// <param name="fnc">mapping function</param>
-        /// <param name="src">source enumerator</param>
-        public Mapped(Func<In, Out> fnc, ICollection<In> src) : base(
-            () =>
-            new LiveList<Out>(
-                  new Collection.Mapped<In, Out>(fnc, src)
+        public Mapped(Func<In, Out> mapping, IEnumerable<In> src) : base(() =>
+            new ListOf<Out>(
+                new Collection.Mapped<In, Out>(mapping, src)
             ),
             false
         )
         { }
 
-}
+        /// <summary>
+        /// ctor
+        /// </summary>
+        /// <param name="mapping">mapping function</param>
+        /// <param name="src">source enumerator</param>
+        public Mapped(Func<In, Out> mapping, ICollection<In> src) : base(() =>
+            new ListOf<Out>(
+                new Collection.Mapped<In, Out>(mapping, src)
+            ),
+            false
+        )
+        { }
+
+    }
 }

--- a/src/Yaapii.Atoms/Lists/SolidList.cs
+++ b/src/Yaapii.Atoms/Lists/SolidList.cs
@@ -42,23 +42,33 @@ namespace Yaapii.Atoms.List
         /// ctor
         /// </summary>
         /// <param name="items">items to decorate</param>
-        public SolidList(IEnumerable<T> items) : this(new LiveList<T>(items))
+        public SolidList(IEnumerable<T> items) : base(() =>
+            new SyncList<T>(
+                new ListOf<T>(items)
+            ),
+            false
+        )
         { }
 
         /// <summary>
         /// ctor
         /// </summary>
-        /// <param name="items">items to decorate</param>
-        public SolidList(IEnumerator<T> items) : this(new LiveList<T>(items))
+        /// <param name="enumerator">items to decorate</param>
+        public SolidList(IEnumerator<T> enumerator) : base(() =>
+            new SyncList<T>(
+                new ListOf<T>(enumerator)
+            ),
+            false
+        )
         { }
 
         /// <summary>
         /// ctor
         /// </summary>
         /// <param name="list">list to decorate</param>
-        public SolidList(ICollection<T> list) : base(
-            () => new SyncList<T>(
-                new LiveList<T>(list)
+        public SolidList(ICollection<T> list) : base(() =>
+            new SyncList<T>(
+                new ListOf<T>(list)
             ),
             false
         )

--- a/src/Yaapii.Atoms/Lists/SyncList.cs
+++ b/src/Yaapii.Atoms/Lists/SyncList.cs
@@ -35,38 +35,53 @@ namespace Yaapii.Atoms.List
         /// <summary>
         /// ctor
         /// </summary>
-        /// <param name="items">source items</param>
-        public SyncList(params T[] items) : this(new ManyOf<T>(items))
+        public SyncList() : this(new object())
         { }
 
         /// <summary>
         /// ctor
         /// </summary>
-        /// <param name="items">source items</param>
-        public SyncList(IEnumerable<T> items) : this(new LiveList<T>(items))
+        /// <param name="syncRoot"></param>
+        public SyncList(object syncRoot) : this(syncRoot, new ListOf<T>())
         { }
 
         /// <summary>
         /// ctor
         /// </summary>
-        /// <param name="items">source item enumerator</param>
-        public SyncList(IEnumerator<T> items) : this(new LiveList<T>(items))
+        /// <param name="items">items to make collection from</param>
+        public SyncList(params T[] items) : this(new ListOf<T>(items))
         { }
 
         /// <summary>
         /// ctor
         /// </summary>
-        /// <param name="list">A threadsafe list</param>
-        public SyncList(ICollection<T> list) : base(
+        /// <param name="lst">Collection to sync</param>
+        public SyncList(IList<T> lst) : this(lst, lst)
+        { }
+
+        /// <summary>
+        /// ctor
+        /// </summary>
+        /// <param name="syncRoot">root object to sync</param>
+        /// <param name="col"></param>
+        public SyncList(object syncRoot, IList<T> col) : base(
             new Scalar.Sync<IList<T>>(
                 new Live<IList<T>>(() =>
-                    new LiveList<T>(
-                        new Collection.Sync<T>(list)
-                    )
-                )
+                {
+                    lock (syncRoot)
+                    {
+                        var tmp = new List<T>();
+                        foreach (var item in col)
+                        {
+                            tmp.Add(item);
+                        }
+                        return tmp;
+                    }
+                })
             ),
             false
         )
         { }
+
     }
 }

--- a/src/Yaapii.Atoms/Map/Grouped.cs
+++ b/src/Yaapii.Atoms/Map/Grouped.cs
@@ -39,20 +39,7 @@ namespace Yaapii.Atoms.Map
         /// <param name="src">Source Enumerable</param>
         /// <param name="key">Function to convert Source Type to Key Type</param>
         /// <param name="value">Function to Convert Source Type to Key Týpe</param>
-        public Grouped(IEnumerable<T> src, IFunc<T, Key> key, IFunc<T, Value> value) : this(
-            new LiveList<T>(src),
-            key,
-            value
-        )
-        { }
-
-        /// <summary>
-        /// ctor
-        /// </summary>
-        /// <param name="src">Source Enumerable</param>
-        /// <param name="key">Function to convert Source Type to Key Type</param>
-        /// <param name="value">Function to Convert Source Type to Key Týpe</param>
-        public Grouped(IList<T> src, IFunc<T, Key> key, IFunc<T, Value> value) : base(
+        public Grouped(IEnumerable<T> src, IFunc<T, Key> key, IFunc<T, Value> value) : base(
             () =>
             {
                 Dictionary<Key, IList<Value>> temp = new Dictionary<Key, IList<Value>>();

--- a/src/Yaapii.Atoms/Map/Joined.cs
+++ b/src/Yaapii.Atoms/Map/Joined.cs
@@ -36,9 +36,7 @@ namespace Yaapii.Atoms.Map
         /// Joined map.
         /// </summary>
         public Joined(IKvp kvp, IDictionary<string, string> origin) : this(
-            new LiveMap(() =>
-                new LiveMany<IKvp>(kvp)
-            ),
+            new MapOf(kvp),
             origin
         )
         { }
@@ -47,9 +45,7 @@ namespace Yaapii.Atoms.Map
         /// Joined map.
         /// </summary>
         public Joined(IMapInput input, IDictionary<string, string> origin) : this(
-            new LiveMap(() =>
-                new MapOf(input)
-            ),
+            new MapOf(input),
             origin
         )
         { }
@@ -140,8 +136,7 @@ namespace Yaapii.Atoms.Map
                 new LazyDict<string, Value>(
                     new Enumerable.Joined<IKvp<string, Value>>(
                         new Mapped<IDictionary<string, Value>, IEnumerable<IKvp<string, Value>>>(dict =>
-                            new ManyOf<IKvp<string, Value>>(
-                                new ScalarOf<IEnumerator<IKvp<string, Value>>>(() =>
+                            new LiveMany<IKvp<string, Value>>(() =>
                                 {
                                     IEnumerable<IKvp<string, Value>> list = new ManyOf<IKvp<string, Value>>();
                                     foreach (var key in dict.Keys)
@@ -149,7 +144,7 @@ namespace Yaapii.Atoms.Map
                                         list = new Enumerable.Joined<IKvp<string, Value>>(list, new KvpOf<string, Value>(key, () => dict[key]));
                                     }
                                     return list.GetEnumerator();
-                                })
+                                }
                             ),
                             dicts
                         )
@@ -211,16 +206,15 @@ namespace Yaapii.Atoms.Map
                 new LazyDict<Key, Value>(
                     new Enumerable.Joined<IKvp<Key, Value>>(
                         new Mapped<IDictionary<Key, Value>, IEnumerable<IKvp<Key, Value>>>(dict =>
-                            new ManyOf<IKvp<Key, Value>>(
-                                new ScalarOf<IEnumerator<IKvp<Key, Value>>>(() =>
-                                  {
-                                      IEnumerable<IKvp<Key, Value>> list = new ManyOf<IKvp<Key, Value>>();
-                                      foreach (var key in dict.Keys)
-                                      {
-                                          list = new Enumerable.Joined<IKvp<Key, Value>>(list, new KvpOf<Key, Value>(key, () => dict[key]));
-                                      }
-                                      return list.GetEnumerator();
-                                  })
+                            new LiveMany<IKvp<Key, Value>>(() =>
+                                {
+                                    IEnumerable<IKvp<Key, Value>> list = new ManyOf<IKvp<Key, Value>>();
+                                    foreach (var key in dict.Keys)
+                                    {
+                                        list = new Enumerable.Joined<IKvp<Key, Value>>(list, new KvpOf<Key, Value>(key, () => dict[key]));
+                                    }
+                                    return list.GetEnumerator();
+                                }
                             ),
                             dicts
                         )

--- a/src/Yaapii.Atoms/Map/LazyDict.cs
+++ b/src/Yaapii.Atoms/Map/LazyDict.cs
@@ -110,11 +110,9 @@ namespace Yaapii.Atoms.Map
                         + " If you need this behaviour, set the ctor param 'rejectBuildingAllValues' to false.");
                 }
                 return
-                    new LiveList<string>(
-                       new Enumerable.Mapped<ScalarOf<string>, string>(
-                           v => v.Value(),
-                           map.Values
-                       )
+                    new List.Mapped<ScalarOf<string>, string>(
+                        v => v.Value(),
+                        map.Values
                    );
             }
         }
@@ -350,11 +348,9 @@ namespace Yaapii.Atoms.Map
                         + " If you need this behaviour, set the ctor param 'rejectBuildingAllValues' to false.");
                 }
                 return
-                    new LiveList<Value>(
-                       new Enumerable.Mapped<ScalarOf<Value>, Value>(
-                           v => v.Value(),
-                           map.Values
-                       )
+                    new List.Mapped<ScalarOf<Value>, Value>(
+                        v => v.Value(),
+                        map.Values
                    );
             }
         }
@@ -590,11 +586,10 @@ namespace Yaapii.Atoms.Map
                         + " If you need this behaviour, set the ctor param 'rejectBuildingAllValues' to false.");
                 }
                 return
-                    new LiveList<Value>(
-                       new Enumerable.Mapped<ScalarOf<Value>, Value>(
-                           v => v.Value(),
-                           map.Values
-                       )
+                    new List.Mapped<ScalarOf<Value>, Value>(
+                        v => v.Value(),
+                        map.Values
+                       
                    );
             }
         }

--- a/src/Yaapii.Atoms/Map/MapOf.cs
+++ b/src/Yaapii.Atoms/Map/MapOf.cs
@@ -285,7 +285,7 @@ namespace Yaapii.Atoms.Map
         /// </summary>
         /// <param name="inputs">inputs</param>
         public MapOf(params IMapInput<Value>[] inputs) : this(
-            new LiveMany<IMapInput<Value>>(inputs)
+            new ManyOf<IMapInput<Value>>(inputs)
         )
         { }
 
@@ -326,7 +326,7 @@ namespace Yaapii.Atoms.Map
         /// </summary>
         public MapOf(KeyValuePair<Key, Value> item, params KeyValuePair<Key, Value>[] more) : this(
             new Enumerable.Joined<KeyValuePair<Key, Value>>(
-                new LiveMany<KeyValuePair<Key, Value>>(more),
+                new ManyOf<KeyValuePair<Key, Value>>(more),
                 item
             )
         )
@@ -339,7 +339,7 @@ namespace Yaapii.Atoms.Map
         /// <param name="list">KeyValuePairs to append</param>
         public MapOf(IDictionary<Key, Value> src, params KeyValuePair<Key, Value>[] list) : this(
             src,
-            new LiveMany<KeyValuePair<Key, Value>>(list))
+            new ManyOf<KeyValuePair<Key, Value>>(list))
         { }
 
         /// <summary>
@@ -416,7 +416,7 @@ namespace Yaapii.Atoms.Map
         /// A map from the given inputs.
         /// </summary>
         /// <param name="inputs">inputs</param>
-        public MapOf(params IMapInput<Key, Value>[] inputs) : this(new ManyOf<IMapInput<Key, Value>>(inputs))
+        public MapOf(params IMapInput<Key, Value>[] inputs) : this(new LiveMany<IMapInput<Key, Value>>(inputs))
         { }
 
         /// <summary>

--- a/src/Yaapii.Atoms/Text/Strict.cs
+++ b/src/Yaapii.Atoms/Text/Strict.cs
@@ -40,7 +40,7 @@ namespace Yaapii.Atoms.Text
         /// <param name="ignoreCase">Ignore case in the canidate and valid texts</param>
         /// <param name="valid">The valid texts</param>
         public Strict(string candidate, bool ignoreCase, params string[] valid) : this(
-            candidate, ignoreCase, new LiveMany<string>(valid)
+            candidate, ignoreCase, new ManyOf<string>(valid)
         )
         { }
 

--- a/tests/Yaapii.Atoms.Tests/Enumerable/FilteredTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Enumerable/FilteredTest.cs
@@ -29,6 +29,7 @@ using Yaapii.Atoms.Func;
 using System.Linq;
 using Yaapii.Atoms.Tests;
 using Yaapii.Atoms.Enumerable;
+using System.Diagnostics;
 
 namespace Yaapii.Atoms.Enumerable.Tests
 {
@@ -75,14 +76,53 @@ namespace Yaapii.Atoms.Enumerable.Tests
         }
 
         [Fact]
-        public void FilterItemsGivenByParamsCtor()
+        public void FiltersItemsGivenByParamsCtor()
         {
             Assert.True(
                 new LengthOf(
                     new Filtered<string>(
                        (input) => input != "B",
-                       "A", "B", "C")).Value() == 2,
-                "cannot filter items");
+                       "A", "B", "C")
+                ).Value() == 2,
+                "cannot filter items"
+            );
+        }
+
+        [Fact]
+        public void IsSticky()
+        {
+            var calls = 0;
+
+            var enm =
+                new Filtered<string>(
+                    (i) => { Debug.WriteLine("Read"); return true; },
+                    new List<string>() { "A" }
+                );
+
+            var enmr1 = enm.GetEnumerator();
+            var enmr2 = enm.GetEnumerator();
+
+            enmr1.MoveNext();
+            enmr2.MoveNext();
+
+
+            var enumerable =
+                new Filtered<string>(
+                    (input) =>
+                    {
+                        calls++;
+                        return input != "B";
+                    },
+                    new List<string>() { "A", "B", "C" }
+                );
+
+            new LengthOf(enumerable).Value();
+            new LengthOf(enumerable).Value();
+
+            Assert.Equal(
+                3,
+                calls
+            );
         }
     }
 }

--- a/tests/Yaapii.Atoms.Tests/Enumerable/ManyLiveTests.cs
+++ b/tests/Yaapii.Atoms.Tests/Enumerable/ManyLiveTests.cs
@@ -33,7 +33,7 @@ namespace Yaapii.Atoms.Enumerable.Tests
         {
             Assert.True(
                 new LengthOf(
-                    new LiveMany<string>(
+                    new ManyOf<string>(
                         "a", "b", "c"
                     )
                 ).Value() == 3,
@@ -45,7 +45,7 @@ namespace Yaapii.Atoms.Enumerable.Tests
         {
             Assert.True(
                 new LengthOf(
-                    new LiveMany<IText>(
+                    new ManyOf<IText>(
                         new LiveText("a"), 
                         new LiveText("b"), 
                         new LiveText("c")

--- a/tests/Yaapii.Atoms.Tests/Enumerator/CachedTests.cs
+++ b/tests/Yaapii.Atoms.Tests/Enumerator/CachedTests.cs
@@ -1,0 +1,89 @@
+﻿// MIT License
+//
+// Copyright(c) 2020 ICARUS Consulting GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace Yaapii.Atoms.Enumerator
+{
+    public sealed class CachedTests
+    {
+        [Fact]
+        public void DeliversMovementAbilityFromCache()
+        {
+            var advances = 0;
+            var contents = new List<int>() { 1 };
+            var enumerator =
+                new Cached<int>(
+                    new Cached<int>.Cache<int>(() => contents.GetEnumerator())
+                );
+
+            while (enumerator.MoveNext())
+            {
+                advances++;
+            }
+
+            contents.Clear();
+            enumerator.Reset();
+            Assert.True(enumerator.MoveNext());
+        }
+
+        [Fact]
+        public void DeliversFromCache()
+        {
+            var advances = 0;
+            var contents = new List<int>() { 1, 2, 3 };
+            var enumerator =
+                new Cached<int>(
+                    new Cached<int>.Cache<int>(() => contents.GetEnumerator())
+                );
+
+            while (enumerator.MoveNext())
+            {
+                advances++;
+            }
+
+            contents.Clear();
+            enumerator.Reset();
+
+            var result = new List<int>();
+            while (enumerator.MoveNext())
+            {
+                result.Add(enumerator.Current);
+            }
+            Assert.Equal(new List<int>() { 1, 2, 3 }, result);
+        }
+
+        [Fact]
+        public void CacheCachesItemCount()
+        {
+            var contents = new List<int>() { 1 };
+            var cache = new Cached<int>.Cache<int>(() => contents.GetEnumerator());
+
+            var count = cache.Count;
+
+            contents.Clear();
+
+            Assert.True(cache.Count == 1);
+        }
+    }
+}

--- a/tests/Yaapii.Atoms.Tests/Lists/LiveListTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Lists/LiveListTest.cs
@@ -28,33 +28,13 @@ using Yaapii.Atoms.Scalar;
 
 namespace Yaapii.Atoms.List.Tests
 {
-    public sealed class ListLiveTest
+    public sealed class LiveListTest
     {
-        [Fact]
-        public void BehavesAsList()
-        {
-            Assert.Contains<int>(
-                2,
-                new LiveList<int>(1, 2)
-            );
-        }
-
-        [Fact]
-        public void ElementAtIndexTest()
-        {
-            int num = 345;
-
-            Assert.Equal(
-                num,
-                new LiveList<int>(-1, num, 0, 1)[1]
-            );
-        }
-
         [Fact]
         public void KnowsIfEmpty()
         {
             Assert.Empty(
-                new LiveList<int>(
+                new LiveList<int>(() =>
                     new List<int>()
                 )
             );
@@ -65,7 +45,7 @@ namespace Yaapii.Atoms.List.Tests
         {
             Assert.Throws<ArgumentOutOfRangeException>(
                 () => 
-                new LiveList<int>(
+                new LiveList<int>(() =>
                     new List<int>() { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
                     [-1]);
         }
@@ -75,7 +55,7 @@ namespace Yaapii.Atoms.List.Tests
         {
             Assert.Throws<ArgumentOutOfRangeException>(
                 () =>
-                new LiveList<int>(
+                new LiveList<int>(() =>
                     new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
                         [11]);
         }
@@ -85,11 +65,15 @@ namespace Yaapii.Atoms.List.Tests
         {
             int size = 2;
             var list =
-                new LiveList<int>(
-                    new Yaapii.Atoms.Enumerable.HeadOf<int>(
-                        new Yaapii.Atoms.Enumerable.Endless<int>(1),
-                        new Live<int>(() => Interlocked.Increment(ref size))
-                ));
+                new LiveList<int>(() =>
+                    new ListOf<int>(
+                        new Yaapii.Atoms.Enumerable.HeadOf<int>(
+                            new Yaapii.Atoms.Enumerable.Endless<int>(1),
+                                new Live<int>(() => Interlocked.Increment(ref size)
+                            )
+                        )
+                    )
+                );
 
             Assert.NotEqual(list.Count, list.Count);
         }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
ManyEnvelope (using live: false) is not sticky like most users expect: While the main Enumerable object is indeed sticky, its contents may differ each time the enumerator is generated.

### What is the new behavior?
This led to confusion so the design is changed: The items are sticky, so every iteration will give the same results. 

closes #425 

### Does this PR introduce a breaking change? (check one with "x")
- [ ] Yes
- [ ] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications

###  Other information