### PR TITLE
Rename IText.AsString to IText.ToString

### DIFF
--- a/src/Yaapii.Atoms/Bytes/BytesOf.cs
+++ b/src/Yaapii.Atoms/Bytes/BytesOf.cs
@@ -156,7 +156,7 @@ namespace Yaapii.Atoms.Bytes
         /// <param name="text">a text</param>
         /// <param name="encoding">encoding of the string</param>
         public BytesOf(IText text, Encoding encoding) : this(
-            () => encoding.GetBytes(text.AsString()))
+            () => encoding.GetBytes(text.ToString()))
         { }
 
         /// <summary>

--- a/src/Yaapii.Atoms/Bytes/HexBytes.cs
+++ b/src/Yaapii.Atoms/Bytes/HexBytes.cs
@@ -48,7 +48,7 @@ namespace Yaapii.Atoms.Bytes
         {
             this.bytes = new ScalarOf<byte[]>(() =>
             {
-                var hex = origin.AsString();
+                var hex = origin.ToString();
                 if ((hex.Length & 1) == 1)
                 {
                     throw new IOException("Length of hexadecimal text is odd");

--- a/src/Yaapii.Atoms/Enumerator/ItemAt.cs
+++ b/src/Yaapii.Atoms/Enumerator/ItemAt.cs
@@ -64,7 +64,7 @@ namespace Yaapii.Atoms.Enumerator
                     {
                         throw
                             new NoSuchElementException(
-                                new Formatted("Cannot get item: {0}", ex.Message).AsString()
+                                new Formatted("Cannot get item: {0}", ex.Message).ToString()
                             );
                     })
                 )
@@ -123,7 +123,7 @@ namespace Yaapii.Atoms.Enumerator
                                 new Formatted(
                                     "Cannot get item: {0}",
                                     ex.Message
-                                ).AsString());
+                                ).ToString());
                     }
             ))
         { }
@@ -160,7 +160,7 @@ namespace Yaapii.Atoms.Enumerator
                         new Formatted(
                             "The position must be non-negative but is {0}",
                             this.pos
-                        ).AsString()
+                        ).ToString()
                     )
                 ).Go();
 

--- a/src/Yaapii.Atoms/Enumerator/Sibling.cs
+++ b/src/Yaapii.Atoms/Enumerator/Sibling.cs
@@ -105,7 +105,7 @@ namespace Yaapii.Atoms.Enumerator
                             new Formatted(
                                 "Enumerator doesn't have a neighbour at position {0}",
                                 pos
-                            ).AsString()
+                            ).ToString()
                         );
                     }
             ))

--- a/src/Yaapii.Atoms/Error/FailAlways.cs
+++ b/src/Yaapii.Atoms/Error/FailAlways.cs
@@ -43,7 +43,7 @@ namespace Yaapii.Atoms.Error
         /// Fail always with <see cref="System.Exception"/> with the given message.
         /// </summary>
         /// <param name="msg">message to wrap in exception</param>
-        public FailAlways(IText msg) : this(() => new Exception(msg.AsString()))
+        public FailAlways(IText msg) : this(() => new Exception(msg.ToString()))
         { }
 
         /// <summary>

--- a/src/Yaapii.Atoms/IO/DecodedUrl.cs
+++ b/src/Yaapii.Atoms/IO/DecodedUrl.cs
@@ -68,7 +68,7 @@ namespace Yaapii.Atoms.IO
         public String Value()
         {
             return WebUtility.UrlDecode(
-                this.source.AsString()
+                this.source.ToString()
             );
         }
     }

--- a/src/Yaapii.Atoms/IO/Directory.cs
+++ b/src/Yaapii.Atoms/IO/Directory.cs
@@ -59,7 +59,7 @@ namespace Yaapii.Atoms.IO
                 {
                     throw
                      new ArgumentException(
-                         new Formatted("'{0}' is not a directory.", file.ToString()).AsString()
+                         new Formatted("'{0}' is not a directory.", file.ToString()).ToString()
                      );
                 }
                 return file.AbsolutePath;
@@ -128,7 +128,7 @@ namespace Yaapii.Atoms.IO
                     throw
                         new ArgumentException(
                             new Formatted("'{0}' is not a directory.", path.Value()
-                        ).AsString()
+                        ).ToString()
                     );
                 }
 

--- a/src/Yaapii.Atoms/IO/ResourceNotFoundException.cs
+++ b/src/Yaapii.Atoms/IO/ResourceNotFoundException.cs
@@ -41,8 +41,8 @@ namespace Yaapii.Atoms.IO.Error
                 "Resource '{0}' not found.\r\n{1} resources are available\r\n{2}",
                 missing,
                 container.GetManifestResourceNames().Length,
-                new Joined("\r\n", container.GetManifestResourceNames()).AsString()
-            ).AsString()
+                new Joined("\r\n", container.GetManifestResourceNames()).ToString()
+            ).ToString()
         )
         { }
     }

--- a/src/Yaapii.Atoms/IO/Zip.cs
+++ b/src/Yaapii.Atoms/IO/Zip.cs
@@ -74,7 +74,7 @@ public sealed class Zip : IInput
                 new Formatted(
                     "Path is not a directory or does not exist: {0}",
                     path
-                ).AsString()
+                ).ToString()
             )
         ).Go();
     }

--- a/src/Yaapii.Atoms/IText.cs
+++ b/src/Yaapii.Atoms/IText.cs
@@ -33,6 +33,6 @@ namespace Yaapii.Atoms
         /// Get content as a string.
         /// </summary>
         /// <returns>the content as a string</returns>
-        String AsString();
+        String ToString();
     }
 }

--- a/src/Yaapii.Atoms/Map/KvpOf.cs
+++ b/src/Yaapii.Atoms/Map/KvpOf.cs
@@ -40,14 +40,14 @@ namespace Yaapii.Atoms.Map
         /// Key-value pair made of strings.
         /// </summary>
         public KvpOf(IText key, Func<string> value)
-            : this(key.AsString(), value)
+            : this(key.ToString(), value)
         { }
 
         /// <summary>
         /// Key-value pair made of strings.
         /// </summary>
         public KvpOf(IText key, string value)
-            : this(key.AsString(), value)
+            : this(key.ToString(), value)
         { }
 
         /// <summary>
@@ -125,14 +125,14 @@ namespace Yaapii.Atoms.Map
         /// Key-value pair matching a string to specified type value.
         /// </summary>
         public KvpOf(IText key, Func<TValue> value)
-            : this(key.AsString(), value)
+            : this(key.ToString(), value)
         { }
 
         /// <summary>
         /// Key-value pair matching a string to specified type value.
         /// </summary>
         public KvpOf(IText key, TValue value)
-            : this(key.AsString(), value)
+            : this(key.ToString(), value)
         { }
 
         /// <summary>

--- a/src/Yaapii.Atoms/Map/LazyDict.cs
+++ b/src/Yaapii.Atoms/Map/LazyDict.cs
@@ -196,7 +196,7 @@ namespace Yaapii.Atoms.Map
                             "arrayIndex {0} is higher than the item count in the map {1}.",
                             arrayIndex,
                             this.map.Count
-                        ).AsString());
+                        ).ToString());
             }
 
             new ListOf<KeyValuePair<string, string>>(this).CopyTo(array, arrayIndex);
@@ -433,7 +433,7 @@ namespace Yaapii.Atoms.Map
                             "arrayIndex {0} is higher than the item count in the map {1}.",
                             arrayIndex,
                             this.map.Count
-                        ).AsString());
+                        ).ToString());
             }
 
             new ListOf<KeyValuePair<string, Value>>(this).CopyTo(array, arrayIndex);
@@ -674,7 +674,7 @@ namespace Yaapii.Atoms.Map
                             "arrayIndex {0} is higher than the item count in the map {1}.",
                             arrayIndex,
                             this.map.Count
-                        ).AsString());
+                        ).ToString());
             }
 
             new ListOf<KeyValuePair<Key, Value>>(this).CopyTo(array, arrayIndex);

--- a/src/Yaapii.Atoms/Map/MapEnvelope.cs
+++ b/src/Yaapii.Atoms/Map/MapEnvelope.cs
@@ -61,7 +61,7 @@ namespace Yaapii.Atoms.Map
                 }
                 catch (KeyNotFoundException)
                 {
-                    var keysString = new Text.Joined(", ", val.Keys).AsString();
+                    var keysString = new Text.Joined(", ", val.Keys).ToString();
                     throw new ArgumentException($"The key '{key}' is not present in the map. The following keys are present in the map: {keysString}");
                 }
             }
@@ -179,7 +179,7 @@ namespace Yaapii.Atoms.Map
                 }
                 catch (KeyNotFoundException)
                 {
-                    var keysString = new Text.Joined(", ", val.Keys).AsString();
+                    var keysString = new Text.Joined(", ", val.Keys).ToString();
                     throw new ArgumentException($"The key '{key}' is not present in the map. The following keys are present in the map: {keysString}");
                 }
             }

--- a/src/Yaapii.Atoms/Map/VersionMap.cs
+++ b/src/Yaapii.Atoms/Map/VersionMap.cs
@@ -43,7 +43,7 @@ namespace Yaapii.Atoms.Map
                         v => v.ToString(),
                         available
                     )
-                ).AsString()
+                ).ToString()
             );
 
         /// <summary>

--- a/src/Yaapii.Atoms/Number/NumberOf.cs
+++ b/src/Yaapii.Atoms/Number/NumberOf.cs
@@ -111,7 +111,7 @@ namespace Yaapii.Atoms.Number
                 }
                 catch (FormatException)
                 {
-                    throw new ArgumentException(new Formatted("'{0}' is not a number.", str).AsString());
+                    throw new ArgumentException(new Formatted("'{0}' is not a number.", str).ToString());
                 }
             }),
             new ScalarOf<int>(() =>
@@ -122,7 +122,7 @@ namespace Yaapii.Atoms.Number
                 }
                 catch (FormatException)
                 {
-                    throw new ArgumentException(new Formatted("'{0}' is not a number.", str).AsString());
+                    throw new ArgumentException(new Formatted("'{0}' is not a number.", str).ToString());
                 }
             }),
             new ScalarOf<long>(() =>
@@ -133,7 +133,7 @@ namespace Yaapii.Atoms.Number
                 }
                 catch (FormatException)
                 {
-                    throw new ArgumentException(new Formatted("'{0}' is not a number.", str).AsString());
+                    throw new ArgumentException(new Formatted("'{0}' is not a number.", str).ToString());
                 }
             }),
             new ScalarOf<float>(() =>
@@ -144,7 +144,7 @@ namespace Yaapii.Atoms.Number
                 }
                 catch (FormatException)
                 {
-                    throw new ArgumentException(new Formatted("'{0}' is not a number.", str).AsString());
+                    throw new ArgumentException(new Formatted("'{0}' is not a number.", str).ToString());
                 }
             })
         )

--- a/src/Yaapii.Atoms/Primitives/BoolOf.cs
+++ b/src/Yaapii.Atoms/Primitives/BoolOf.cs
@@ -51,7 +51,7 @@ namespace Yaapii.Atoms.Text
                 {
                     try
                     {
-                        return Convert.ToBoolean(text.AsString());
+                        return Convert.ToBoolean(text.ToString());
                     }
                     catch (FormatException ex)
                     {

--- a/src/Yaapii.Atoms/Primitives/DoubleOf.cs
+++ b/src/Yaapii.Atoms/Primitives/DoubleOf.cs
@@ -61,7 +61,7 @@ namespace Yaapii.Atoms.Text
         /// </summary>
         /// <param name="text">a double as a text</param>
         /// <param name="culture">culture of the given text</param>
-        public DoubleOf(IText text, CultureInfo culture) : this(new Live<Double>(() => Convert.ToDouble(text.AsString(), culture.NumberFormat)))
+        public DoubleOf(IText text, CultureInfo culture) : this(new Live<Double>(() => Convert.ToDouble(text.ToString(), culture.NumberFormat)))
         { }
 
         /// <summary>

--- a/src/Yaapii.Atoms/Primitives/FloatOf.cs
+++ b/src/Yaapii.Atoms/Primitives/FloatOf.cs
@@ -64,7 +64,7 @@ namespace Yaapii.Atoms.Text
         /// </summary>
         /// <param name="text">a float as a text</param>
         /// <param name="culture">a culture of the string</param>
-        public FloatOf(IText text, CultureInfo culture) : this(new Live<float>(() => float.Parse(text.AsString(), culture.NumberFormat)))
+        public FloatOf(IText text, CultureInfo culture) : this(new Live<float>(() => float.Parse(text.ToString(), culture.NumberFormat)))
         { }
 
         public FloatOf(IScalar<float> value)

--- a/src/Yaapii.Atoms/Primitives/IntOf.cs
+++ b/src/Yaapii.Atoms/Primitives/IntOf.cs
@@ -60,7 +60,7 @@ namespace Yaapii.Atoms.Text
         /// </summary>
         /// <param name="text">a int as a string</param>
         /// <param name="culture">culture of the string</param>
-        public IntOf(IText text, CultureInfo culture) : this(new ScalarOf<int>(() => Convert.ToInt32(text.AsString(), culture.NumberFormat)))
+        public IntOf(IText text, CultureInfo culture) : this(new ScalarOf<int>(() => Convert.ToInt32(text.ToString(), culture.NumberFormat)))
         { }
 
         /// <summary>

--- a/src/Yaapii.Atoms/Primitives/LongOf.cs
+++ b/src/Yaapii.Atoms/Primitives/LongOf.cs
@@ -60,7 +60,7 @@ namespace Yaapii.Atoms.Text
         /// </summary>
         /// <param name="text">a string as a text</param>
         /// <param name="culture">culture of the text</param>
-        public LongOf(IText text, CultureInfo culture) : this(new ScalarOf<long>(() => Convert.ToInt64(text.AsString(), culture.NumberFormat)))
+        public LongOf(IText text, CultureInfo culture) : this(new ScalarOf<long>(() => Convert.ToInt64(text.ToString(), culture.NumberFormat)))
         { }
 
         /// <summary>

--- a/src/Yaapii.Atoms/Scalar/IsNumber.cs
+++ b/src/Yaapii.Atoms/Scalar/IsNumber.cs
@@ -70,7 +70,7 @@ namespace Yaapii.Atoms.Scalar
         public IsNumber(IText text, IFormatProvider provider)
             : base(() =>
                 double.TryParse(
-                    text.AsString(),
+                    text.ToString(),
                     NumberStyles.Any,
                     provider,
                     out var unused

--- a/src/Yaapii.Atoms/Scalar/ItemAt.cs
+++ b/src/Yaapii.Atoms/Scalar/ItemAt.cs
@@ -70,7 +70,7 @@ namespace Yaapii.Atoms.Enumerable
             source,
             new BiFuncOf<Exception, IEnumerable<T>, T>((ex, itr) =>
                 throw new NoSuchElementException(
-                    new Formatted("Cannot get first element: {0}", ex.Message).AsString()
+                    new Formatted("Cannot get first element: {0}", ex.Message).ToString()
                 )
             )
         )
@@ -152,7 +152,7 @@ namespace Yaapii.Atoms.Enumerable
                                 "Cannot get element at position {0}: {1}",
                                 position,
                                 ex.Message
-                            ).AsString()
+                            ).ToString()
                     );
                 }
             )

--- a/src/Yaapii.Atoms/Scalar/LastOf.cs
+++ b/src/Yaapii.Atoms/Scalar/LastOf.cs
@@ -62,7 +62,7 @@ namespace Yaapii.Atoms.Enumerable
                             new Formatted(
                                 "Cannot get last element: {0}",
                                 ex.Message
-                            ).AsString()
+                            ).ToString()
                     );
                 }))
         { }

--- a/src/Yaapii.Atoms/Text/Base64Text.cs
+++ b/src/Yaapii.Atoms/Text/Base64Text.cs
@@ -48,7 +48,7 @@ namespace Yaapii.Atoms.Text
                 new Base64Bytes(
                     new BytesOf(text)
                 )
-            ).AsString(),
+            ).ToString(),
             live
         )
         { }

--- a/src/Yaapii.Atoms/Text/Comparable.cs
+++ b/src/Yaapii.Atoms/Text/Comparable.cs
@@ -39,7 +39,7 @@ namespace Yaapii.Atoms.Text
         /// </summary>
         public Comparable(IText text) : base(text, false)
         {
-            this.text = new TextOf(() => text.AsString());
+            this.text = new TextOf(() => text.ToString());
         }
 
         public int CompareTo(object obj)
@@ -48,7 +48,7 @@ namespace Yaapii.Atoms.Text
                 obj as IText,
                 "Cannot compare, because given object is not of type IText"
             ).Go();
-            return this.text.AsString().CompareTo(((IText)obj).AsString());
+            return this.text.ToString().CompareTo(((IText)obj).ToString());
         }
     }
 }

--- a/src/Yaapii.Atoms/Text/Contains.cs
+++ b/src/Yaapii.Atoms/Text/Contains.cs
@@ -43,7 +43,7 @@ namespace Yaapii.Atoms.Text
         /// <param name="patternText"> pattern as IText </param>
         /// <param name="ignoreCase"> Enables case sensitivity </param>
         public Contains(IText inputText, IText patternText, bool ignoreCase = false) :
-            this(new Live<string>(() => inputText.AsString()), new Live<string>(() => patternText.AsString()), new Live<StringComparison>(() => ignoreCase ? StringComparison.CurrentCultureIgnoreCase : StringComparison.CurrentCulture))
+            this(new Live<string>(() => inputText.ToString()), new Live<string>(() => patternText.ToString()), new Live<StringComparison>(() => ignoreCase ? StringComparison.CurrentCultureIgnoreCase : StringComparison.CurrentCulture))
         { }
 
         /// <summary> Checks if a text contains a pattern using IScalar </summary>

--- a/src/Yaapii.Atoms/Text/EndsWith.cs
+++ b/src/Yaapii.Atoms/Text/EndsWith.cs
@@ -53,8 +53,8 @@ namespace Yaapii.Atoms.Text
             this.result =
                 new ScalarOf<bool>(() =>
                 {
-                    var regex = new Regex(Regex.Escape(tail.AsString()) + "$");
-                    return regex.IsMatch(text.AsString());
+                    var regex = new Regex(Regex.Escape(tail.ToString()) + "$");
+                    return regex.IsMatch(text.ToString());
                 });
         }
 

--- a/src/Yaapii.Atoms/Text/Formatted.cs
+++ b/src/Yaapii.Atoms/Text/Formatted.cs
@@ -44,7 +44,7 @@ namespace Yaapii.Atoms.Text
             CultureInfo.InvariantCulture,
             () =>
             new Mapped<IText, string>(
-                txt => txt.AsString(),
+                txt => txt.ToString(),
                 arguments
             ).ToArray()
         )
@@ -151,7 +151,7 @@ namespace Yaapii.Atoms.Text
                 object[] strings = new object[new LengthOf(arguments).Value()];
                 for (int i = 0; i < arguments.Length; i++)
                 {
-                    strings[i] = arguments[i].AsString();
+                    strings[i] = arguments[i].ToString();
                 }
                 return strings;
             },
@@ -190,7 +190,7 @@ namespace Yaapii.Atoms.Text
                 object[] strings = new object[new LengthOf(arguments).Value()];
                 for (int i = 0; i < arguments.Length; i++)
                 {
-                    strings[i] = arguments[i].AsString();
+                    strings[i] = arguments[i].ToString();
                 }
                 return strings;
             },
@@ -231,7 +231,7 @@ namespace Yaapii.Atoms.Text
             Func<object[]> arguments,
             bool live = false
         ) : base(
-            () => String.Format(locale, ptn.AsString(), arguments()),
+            () => String.Format(locale, ptn.ToString(), arguments()),
             live
         )
         { }

--- a/src/Yaapii.Atoms/Text/IsWhitespace.cs
+++ b/src/Yaapii.Atoms/Text/IsWhitespace.cs
@@ -48,7 +48,7 @@ namespace Yaapii.Atoms.Text
         /// <param name="text">text to check</param>
         public IsWhitespace(IText text)
         {
-            this.result = new ScalarOf<bool>(() => !text.AsString().ToCharArray().Any(c => !String.IsNullOrWhiteSpace(c + "")));
+            this.result = new ScalarOf<bool>(() => !text.ToString().ToCharArray().Any(c => !String.IsNullOrWhiteSpace(c + "")));
         }
 
         /// <summary>

--- a/src/Yaapii.Atoms/Text/Joined.cs
+++ b/src/Yaapii.Atoms/Text/Joined.cs
@@ -168,9 +168,9 @@ namespace Yaapii.Atoms.Text
         /// <param name="live">should the object build its value live, every time it is used?</param>
         private Joined(IText delimit, Func<IEnumerable<IText>> txts, bool live = false) : base(() =>
             String.Join(
-                delimit.AsString(),
+                delimit.ToString(),
                 new Mapped<IText, string>(
-                    text => text.AsString(),
+                    text => text.ToString(),
                     txts()
                 )
             ),

--- a/src/Yaapii.Atoms/Text/Lower.cs
+++ b/src/Yaapii.Atoms/Text/Lower.cs
@@ -31,7 +31,7 @@ namespace Yaapii.Atoms.Text
         /// A <see cref="IText"/>  as lowercase.
         /// </summary>
         /// <param name="text">text to lower</param>
-        public Lower(IText text) : base(() => text.AsString().ToLower(), false)
+        public Lower(IText text) : base(() => text.ToString().ToLower(), false)
         { }
     }
 }

--- a/src/Yaapii.Atoms/Text/Normalized.cs
+++ b/src/Yaapii.Atoms/Text/Normalized.cs
@@ -42,7 +42,7 @@ namespace Yaapii.Atoms.Text
         /// </summary>
         /// <param name="text">text to normalize</param>
         public Normalized(IText text) : base(() =>
-            Regex.Replace(new Trimmed(text).AsString(), "\\s+", " "),
+            Regex.Replace(new Trimmed(text).ToString(), "\\s+", " "),
             false
         )
         { }

--- a/src/Yaapii.Atoms/Text/NotNull.cs
+++ b/src/Yaapii.Atoms/Text/NotNull.cs
@@ -39,7 +39,7 @@ namespace Yaapii.Atoms.Text
                 {
                     throw new IOException("invalid text (null)");
                 }
-                return text.AsString();
+                return text.ToString();
             },
             false
         )

--- a/src/Yaapii.Atoms/Text/Repeated.cs
+++ b/src/Yaapii.Atoms/Text/Repeated.cs
@@ -52,7 +52,7 @@ namespace Yaapii.Atoms.Text
                 StringBuilder output = new StringBuilder();
                 for (int cnt = 0; cnt < count; ++cnt)
                 {
-                    output.Append(text.AsString());
+                    output.Append(text.ToString());
                 }
                 return output.ToString();
             },

--- a/src/Yaapii.Atoms/Text/Replaced.cs
+++ b/src/Yaapii.Atoms/Text/Replaced.cs
@@ -36,7 +36,7 @@ namespace Yaapii.Atoms.Text
         /// <param name="find">part to replace</param>
         /// <param name="replace">replacement to insert</param>
         public Replaced(IText text, String find, String replace) : base(() =>
-            text.AsString().Replace(find, replace), 
+            text.ToString().Replace(find, replace), 
             false
         )
         { }

--- a/src/Yaapii.Atoms/Text/Reversed.cs
+++ b/src/Yaapii.Atoms/Text/Reversed.cs
@@ -35,7 +35,7 @@ namespace Yaapii.Atoms.Text
         /// <param name="text">text to reverse</param>
         public Reversed(IText text) : base (() => 
             {
-                char[] chararray = text.AsString().ToCharArray();
+                char[] chararray = text.ToString().ToCharArray();
                 Array.Reverse(chararray);
                 string reverseTxt = "";
                 for (int i = 0; i <= chararray.Length - 1; i++)

--- a/src/Yaapii.Atoms/Text/Rotated.cs
+++ b/src/Yaapii.Atoms/Text/Rotated.cs
@@ -37,7 +37,7 @@ namespace Yaapii.Atoms.Text
         /// <param name="shift">direction and amount of chars to rotate (minus means rotate left, plus means rotate right)</param>
         public Rotated(IText text, int shift) : base(() =>
             {
-                var str = text.AsString();
+                var str = text.ToString();
                 int length = str.Length;
                 if (length != 0 && shift != 0 && shift % length != 0)
                 {

--- a/src/Yaapii.Atoms/Text/Split.cs
+++ b/src/Yaapii.Atoms/Text/Split.cs
@@ -81,7 +81,7 @@ namespace Yaapii.Atoms.Text
             {
                 IEnumerable<string> split =
                     new LiveMany<string>(
-                        new Regex(rgx.AsString()).Split(text.AsString())
+                        new Regex(rgx.ToString()).Split(text.ToString())
                     );
 
                 return

--- a/src/Yaapii.Atoms/Text/StartsWith.cs
+++ b/src/Yaapii.Atoms/Text/StartsWith.cs
@@ -54,8 +54,8 @@ namespace Yaapii.Atoms.Text
             this.result =
                 new ScalarOf<bool>(() =>
                 {
-                    var regex = new Regex("^" + Regex.Escape(start.AsString()));
-                    return regex.IsMatch(text.AsString());
+                    var regex = new Regex("^" + Regex.Escape(start.ToString()));
+                    return regex.IsMatch(text.ToString());
                 });
         }
 

--- a/src/Yaapii.Atoms/Text/Strict.cs
+++ b/src/Yaapii.Atoms/Text/Strict.cs
@@ -132,10 +132,10 @@ namespace Yaapii.Atoms.Text
         private Strict(IText candidate, IEnumerable<IText> valid, IScalar<StringComparison> stringComparer) : base(() =>
         {
             var result = false;
-            var str = candidate.AsString();
+            var str = candidate.ToString();
             foreach (var txt in valid)
             {
-                if (txt.AsString().Equals(str, stringComparer.Value()))
+                if (txt.ToString().Equals(str, stringComparer.Value()))
                 {
                     result = true;
                     break;
@@ -143,7 +143,7 @@ namespace Yaapii.Atoms.Text
             }
             if (!result)
             {
-                throw new ArgumentException($"'{str}' is not valid here - expected: {new Joined(", ", valid).AsString()}");
+                throw new ArgumentException($"'{str}' is not valid here - expected: {new Joined(", ", valid).ToString()}");
             }
             return str;
         }, false)

--- a/src/Yaapii.Atoms/Text/SubText.cs
+++ b/src/Yaapii.Atoms/Text/SubText.cs
@@ -59,7 +59,7 @@ namespace Yaapii.Atoms.Text
         public SubText(IText text, int strt) : this(
             text, 
             new Live<Int32>(strt), 
-            new Live<Int32>(() => text.AsString().Length - strt)
+            new Live<Int32>(() => text.ToString().Length - strt)
         )
         { }
 
@@ -104,7 +104,7 @@ namespace Yaapii.Atoms.Text
         public SubText(IText text, Func<Int32> strt, Func<Int32> len) : base(() =>
             {
                 return 
-                    text.AsString().Substring(
+                    text.ToString().Substring(
                         strt(),
                         len()
                     );

--- a/src/Yaapii.Atoms/Text/Synced.cs
+++ b/src/Yaapii.Atoms/Text/Synced.cs
@@ -45,7 +45,7 @@ namespace Yaapii.Atoms.Text
         public Synced(IText text, Object lck) : base(() =>
             {
                 lock (lck) {
-                    return text.AsString();
+                    return text.ToString();
                 }
             },
             true

--- a/src/Yaapii.Atoms/Text/TextEnvelope.cs
+++ b/src/Yaapii.Atoms/Text/TextEnvelope.cs
@@ -42,7 +42,7 @@ namespace Yaapii.Atoms.Text
         /// </summary>
         /// <param name="text">Origin text</param>
         /// <param name="live">should the value be created every time the object is used?</param>
-        public TextEnvelope(IText text, bool live) : this(() => text.AsString(), live)
+        public TextEnvelope(IText text, bool live) : this(() => text.ToString(), live)
         { }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace Yaapii.Atoms.Text
         /// Gives the text as a string.
         /// </summary>
         /// <returns></returns>
-        public String AsString()
+        public String ToString()
         {
             var result = string.Empty;
             if (this.live)

--- a/src/Yaapii.Atoms/Text/TextUri.cs
+++ b/src/Yaapii.Atoms/Text/TextUri.cs
@@ -47,7 +47,7 @@ namespace Yaapii.Atoms.Text
         {
             this.source = 
                 new ScalarOf<Uri>(
-                    new UriBuilder(url.AsString()).Uri
+                    new UriBuilder(url.ToString()).Uri
                 );
         }
 

--- a/src/Yaapii.Atoms/Text/Trimmed.cs
+++ b/src/Yaapii.Atoms/Text/Trimmed.cs
@@ -69,7 +69,7 @@ namespace Yaapii.Atoms.Text
         /// <param name="text">text to trim</param>
         /// <param name="trimText">text that trims the text</param>
         public Trimmed(IText text, IScalar<char[]> trimText) : base(
-            () => text.AsString().Trim(trimText.Value()),
+            () => text.ToString().Trim(trimText.Value()),
             false
         )
         { }
@@ -119,8 +119,8 @@ namespace Yaapii.Atoms.Text
         public Trimmed(IText text, IText removeText, bool ignoreCase) : base(
             () =>
             {
-                string str = text.AsString();
-                string remove = removeText.AsString();
+                string str = text.ToString();
+                string remove = removeText.ToString();
 
                 if (ignoreCase)
                 {

--- a/src/Yaapii.Atoms/Text/TrimmedLeft.cs
+++ b/src/Yaapii.Atoms/Text/TrimmedLeft.cs
@@ -68,7 +68,7 @@ namespace Yaapii.Atoms.Text
         public TrimmedLeft(IText text, IScalar<char[]> trimText) : base(
             () =>
             {
-                return text.AsString().TrimStart(trimText.Value());
+                return text.ToString().TrimStart(trimText.Value());
             },
             false
         )
@@ -119,8 +119,8 @@ namespace Yaapii.Atoms.Text
         public TrimmedLeft(IText text, IText removeText, bool ignoreCase) : base(
             () =>
             {
-                string str = text.AsString();
-                string remove = removeText.AsString();
+                string str = text.ToString();
+                string remove = removeText.ToString();
 
                 if (ignoreCase)
                 {

--- a/src/Yaapii.Atoms/Text/TrimmedRight.cs
+++ b/src/Yaapii.Atoms/Text/TrimmedRight.cs
@@ -69,7 +69,7 @@ namespace Yaapii.Atoms.Text
         /// <param name="text">text to trim</param>
         /// <param name="trimText">text that trims the text</param>
         public TrimmedRight(IText text, IScalar<char[]> trimText) : base(
-            () => text.AsString().TrimEnd(trimText.Value()),
+            () => text.ToString().TrimEnd(trimText.Value()),
             false
         )
         { }
@@ -115,8 +115,8 @@ namespace Yaapii.Atoms.Text
         public TrimmedRight(IText text, IText removeText, bool ignoreCase) : base(
             () =>
             {
-                string str = text.AsString();
-                string remove = removeText.AsString();
+                string str = text.ToString();
+                string remove = removeText.ToString();
 
                 if (ignoreCase)
                 {

--- a/src/Yaapii.Atoms/Text/Upper.cs
+++ b/src/Yaapii.Atoms/Text/Upper.cs
@@ -32,7 +32,7 @@ namespace Yaapii.Atoms.Text
         /// A <see cref="IText"/> as uppercase.
         /// </summary>
         /// <param name="text">text to uppercase</param>
-        public Upper(IText text) : base(() => text.AsString().ToUpper(), false)
+        public Upper(IText text) : base(() => text.ToString().ToUpper(), false)
         { }
     }
 }

--- a/src/Yaapii.Atoms/Time/DateAsText.cs
+++ b/src/Yaapii.Atoms/Time/DateAsText.cs
@@ -96,7 +96,7 @@ namespace Yaapii.Atoms.Time
         {
             this.formatted =
                 new ScalarOf<string>(
-                    () => date.Value().ToString(format.AsString(), provider)
+                    () => date.Value().ToString(format.ToString(), provider)
                 );
         }
 
@@ -116,7 +116,7 @@ namespace Yaapii.Atoms.Time
         /// <returns></returns>
         public bool Equals(IText other)
         {
-            return formatted.Value().Equals(other.AsString());
+            return formatted.Value().Equals(other.ToString());
         }
     }
 }

--- a/src/Yaapii.Atoms/Time/DateOf.cs
+++ b/src/Yaapii.Atoms/Time/DateOf.cs
@@ -77,7 +77,7 @@ namespace Yaapii.Atoms.Time
             new Live<DateTime>(
                 () =>
                     DateTime.Parse(
-                        date.AsString(),
+                        date.ToString(),
                         dateFormat
                     )
                 )

--- a/tests/Yaapii.Atoms.Tests/Bytes/BytesOfTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Bytes/BytesOfTest.cs
@@ -138,7 +138,7 @@ namespace Yaapii.Atoms.IO.Tests
                         Encoding.UTF8,
                         16 << 10
                     )
-                ).AsString() == source
+                ).ToString() == source
             );
         }
 
@@ -170,7 +170,7 @@ namespace Yaapii.Atoms.IO.Tests
                     );
             }
 
-            Assert.Throws<ObjectDisposedException>(() => t.AsString());
+            Assert.Throws<ObjectDisposedException>(() => t.ToString());
         }
 
 
@@ -183,7 +183,7 @@ namespace Yaapii.Atoms.IO.Tests
                     new BytesOf(
                         new InputOf(text)
                         ).AsBytes(),
-                    new BytesOf(text.AsString()).AsBytes()
+                    new BytesOf(text.ToString()).AsBytes()
                 )
             );
         }
@@ -201,7 +201,7 @@ namespace Yaapii.Atoms.IO.Tests
                         new BytesOf(
                             ex
                         )
-                    ).AsString();
+                    ).ToString();
             }
 
             Assert.True(

--- a/tests/Yaapii.Atoms.Tests/Bytes/HexBytesTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Bytes/HexBytesTest.cs
@@ -33,7 +33,7 @@ namespace Yaapii.Atoms.Bytes.Tests
         {
             Assert.Equal(
                     expected,
-                    new LiveText(new HexBytes(new LiveText(hex))).AsString()
+                    new LiveText(new HexBytes(new LiveText(hex))).ToString()
                 );
         }
     }

--- a/tests/Yaapii.Atoms.Tests/Bytes/ReaderAsBytesTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Bytes/ReaderAsBytesTest.cs
@@ -40,7 +40,7 @@ namespace Yaapii.Atoms.Bytes.Tests
                     new StreamReader(
                         new InputOf(source).Stream())
                 )
-            ).AsString() == source);
+            ).ToString() == source);
         }
     }
 }

--- a/tests/Yaapii.Atoms.Tests/Enumerable/MappedTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Enumerable/MappedTest.cs
@@ -38,7 +38,7 @@ namespace Yaapii.Atoms.Enumerable.Tests
                         input => new Upper(new LiveText(input)),
                         new ManyOf<string>("hello", "world", "damn")),
                     0
-                ).Value().AsString()
+                ).Value().ToString()
             );
         }
 
@@ -65,7 +65,7 @@ namespace Yaapii.Atoms.Enumerable.Tests
                         new ManyOf<string>("hello", "world", "damn")
                         ),
                     1
-                ).Value().AsString() == "WORLD1",
+                ).Value().ToString() == "WORLD1",
             "Can't get index of enumerable");
         }
     }

--- a/tests/Yaapii.Atoms.Tests/Enumerable/ReversedTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Enumerable/ReversedTest.cs
@@ -43,7 +43,7 @@ namespace Yaapii.Atoms.Enumerable.Tests
                             "hello", "world", "dude"
                         )
                     )
-                ).AsString() == "dude world hello");
+                ).ToString() == "dude world hello");
         }
     }
 }

--- a/tests/Yaapii.Atoms.Tests/Enumerable/SkippedTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Enumerable/SkippedTest.cs
@@ -41,7 +41,7 @@ namespace Yaapii.Atoms.Enumerable.Tests
                     new Skipped<string>(
                         new ManyOf<string>("one", "two", "three", "four"),
                         2)
-                    ).AsString() == "three, four");
+                    ).ToString() == "three, four");
         }
     }
 }

--- a/tests/Yaapii.Atoms.Tests/Enumerable/SortedTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Enumerable/SortedTest.cs
@@ -44,7 +44,7 @@ namespace Yaapii.Atoms.Enumerable.Tests
                             new ManyOf<int>(3, 2, 10, 44, -6, 0)
                         )
                     )
-                ).AsString() == "-6, 0, 2, 3, 10, 44",
+                ).ToString() == "-6, 0, 2, 3, 10, 44",
             "Can't sort an enumerable");
         }
 
@@ -58,7 +58,7 @@ namespace Yaapii.Atoms.Enumerable.Tests
                         new ManyOf<string>(
                             "a", "c", "hello", "dude", "Friend"
                         )
-                    )).AsString() == "hello, Friend, dude, c, a",
+                    )).ToString() == "hello, Friend, dude, c, a",
                 "Can't sort an enumerable with a custom comparator");
         }
 

--- a/tests/Yaapii.Atoms.Tests/Enumerator/EndlessTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Enumerator/EndlessTest.cs
@@ -44,7 +44,7 @@ namespace Yaapii.Atoms.Enumerator.Tests
                             str => new LiveText(str)
                         )
                     )
-                ).AsString() == expected
+                ).ToString() == expected
             );
 
         }

--- a/tests/Yaapii.Atoms.Tests/Enumerator/FilteredTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Enumerator/FilteredTest.cs
@@ -40,7 +40,7 @@ namespace Yaapii.Atoms.Enumerator.Tests
                             (str) => str != "cruel"
                         )
                     )
-                ).AsString()
+                ).ToString()
              );
         }
     }

--- a/tests/Yaapii.Atoms.Tests/Enumerator/HeadOfTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Enumerator/HeadOfTest.cs
@@ -48,7 +48,7 @@ namespace Yaapii.Atoms.Enumerator.Tests
                             str => new TextOf(str + "")
                         )
                     )
-                ).AsString() == "1, 2",
+                ).ToString() == "1, 2",
                 "cannot limit enumertor contents"
             );
                 

--- a/tests/Yaapii.Atoms.Tests/Enumerator/MappedTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Enumerator/MappedTest.cs
@@ -35,7 +35,7 @@ namespace Yaapii.Atoms.Enumerator.Tests
                 new ItemAt<string>(
                     new Mapped<int, string>(
                         new ManyOf<int>(1).GetEnumerator(),
-                        i => new LiveText(i).AsString()),
+                        i => new LiveText(i).ToString()),
                 0).Value() == "1",
             "cannot map contents of enumerator");
         }

--- a/tests/Yaapii.Atoms.Tests/Enumerator/SortedTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Enumerator/SortedTest.cs
@@ -42,7 +42,7 @@ namespace Yaapii.Atoms.Enumerator.Tests
                                 new LiveMany<string>("B", "A", "C", "F", "E", "D").GetEnumerator()
                         )
                     )
-                ).AsString()
+                ).ToString()
             );
         }
     }

--- a/tests/Yaapii.Atoms.Tests/Func/BowActionTests.cs
+++ b/tests/Yaapii.Atoms.Tests/Func/BowActionTests.cs
@@ -41,7 +41,7 @@ namespace Yaapii.Atoms.Func.Tests
 
             Assert.Equal(
                 "ask trigger, ask trigger, shoot",
-                new Joined(", ", actions).AsString()
+                new Joined(", ", actions).ToString()
             );
         }
 
@@ -58,7 +58,7 @@ namespace Yaapii.Atoms.Func.Tests
 
             Assert.Equal(
                 "prepare, ask trigger, ask trigger, shoot",
-                new Joined(", ", actions).AsString()
+                new Joined(", ", actions).ToString()
             );
         }
 

--- a/tests/Yaapii.Atoms.Tests/Func/BowFuncTests.cs
+++ b/tests/Yaapii.Atoms.Tests/Func/BowFuncTests.cs
@@ -41,7 +41,7 @@ namespace Yaapii.Atoms.Func.Tests
 
             Assert.Equal(
                 "ask trigger, ask trigger, shoot",
-                new Joined(", ", actions).AsString()
+                new Joined(", ", actions).ToString()
             );
         }
 
@@ -59,7 +59,7 @@ namespace Yaapii.Atoms.Func.Tests
 
             Assert.Equal(
                 "prepare, ask trigger, ask trigger, shoot",
-                new Joined(", ", actions).AsString()
+                new Joined(", ", actions).ToString()
             );
         }
 
@@ -77,7 +77,7 @@ namespace Yaapii.Atoms.Func.Tests
 
             Assert.Equal(
                 "prepare, ask trigger, ask trigger, test",
-                new Joined(", ", actions).AsString()
+                new Joined(", ", actions).ToString()
             );
         }
 

--- a/tests/Yaapii.Atoms.Tests/IO/AppendToTests.cs
+++ b/tests/Yaapii.Atoms.Tests/IO/AppendToTests.cs
@@ -53,7 +53,7 @@ namespace Yaapii.Atoms.IO.Tests
                 new LiveText(
                     new InputAsBytes(
                         new InputOf(new Uri(file))))
-                .AsString() == (txt + txt),
+                .ToString() == (txt + txt),
                 "Can't append path content");
         }
 
@@ -81,7 +81,7 @@ namespace Yaapii.Atoms.IO.Tests
                 new LiveText(
                     new InputAsBytes(
                         new InputOf(file)))
-                .AsString() == txt + txt
+                .ToString() == txt + txt
             );
         }
 

--- a/tests/Yaapii.Atoms.Tests/IO/DeadInputTest.cs
+++ b/tests/Yaapii.Atoms.Tests/IO/DeadInputTest.cs
@@ -33,7 +33,7 @@ namespace Yaapii.Atoms.IO.Tests
             Assert.True(
                 new LiveText(
                     new DeadInput())
-                .AsString() == "",
+                .ToString() == "",
                 "Can't read empty content");
         }
 

--- a/tests/Yaapii.Atoms.Tests/IO/DeadOutputTest.cs
+++ b/tests/Yaapii.Atoms.Tests/IO/DeadOutputTest.cs
@@ -40,7 +40,7 @@ namespace Yaapii.Atoms.IO.Tests
                 new TeeInput(
                     new InputOf("How are you, мой друг?"),
                     new DeadOutput()
-                )).AsString());
+                )).ToString());
         }
     }
 }

--- a/tests/Yaapii.Atoms.Tests/IO/GZipInputTests.cs
+++ b/tests/Yaapii.Atoms.Tests/IO/GZipInputTests.cs
@@ -48,7 +48,7 @@ namespace Yaapii.Atoms.IO.Tests
                 "Hello!",
                 new LiveText(
                     new GZipInput(new InputOf(bytes))
-                ).AsString()
+                ).ToString()
             );
         }
     }

--- a/tests/Yaapii.Atoms.Tests/IO/HeadInputStreamTest.cs
+++ b/tests/Yaapii.Atoms.Tests/IO/HeadInputStreamTest.cs
@@ -50,7 +50,7 @@ namespace Yaapii.Atoms.IO.Tests
 
             Assert.Contains(
                 "tS",
-                new TextOf(new InputOf(stream)).AsString()
+                new TextOf(new InputOf(stream)).ToString()
             );
         }
 
@@ -69,7 +69,7 @@ namespace Yaapii.Atoms.IO.Tests
                 skipped
             );
 
-            var input = new TextOf(stream).AsString();
+            var input = new TextOf(stream).ToString();
             Assert.Equal(
                 "",
                 input

--- a/tests/Yaapii.Atoms.Tests/IO/HeadOfTest.cs
+++ b/tests/Yaapii.Atoms.Tests/IO/HeadOfTest.cs
@@ -41,7 +41,7 @@ namespace Yaapii.Atoms.IO.Tests
                         new InputOf("readsHeadOfLongInput"),
                         5
                     )
-                ).AsString()
+                ).ToString()
             );
         }
 
@@ -54,7 +54,7 @@ namespace Yaapii.Atoms.IO.Tests
                         new InputOf("readsHeadOfLongInput"),
                         5
                     )
-                ).AsString();
+                ).ToString();
 
             Assert.Equal(
                 5,
@@ -76,7 +76,7 @@ namespace Yaapii.Atoms.IO.Tests
                         new InputOf("readsEmptyHeadOfInput"),
                         0
                     )
-                ).AsString()
+                ).ToString()
             );
         }
 
@@ -91,7 +91,7 @@ namespace Yaapii.Atoms.IO.Tests
                         new InputOf(input),
                         35
                     )
-                ).AsString()
+                ).ToString()
             );
         }
     }

--- a/tests/Yaapii.Atoms.Tests/IO/InputOfTest.cs
+++ b/tests/Yaapii.Atoms.Tests/IO/InputOfTest.cs
@@ -47,7 +47,7 @@ namespace Yaapii.Atoms.IO.Tests
                         ),
                         new InputOf(new LiveText("Alternative text!"))
                     )
-                ).AsString().EndsWith("text!"),
+                ).ToString().EndsWith("text!"),
                 "Can't read alternative source from file not found");
         }
 
@@ -81,7 +81,7 @@ namespace Yaapii.Atoms.IO.Tests
                     new LiveText(
                         new InputOf(
                             new Uri(path))
-                    ).AsString().EndsWith(content),
+                    ).ToString().EndsWith(content),
                     "Can't read file content");
         }
 
@@ -93,7 +93,7 @@ namespace Yaapii.Atoms.IO.Tests
             {
                 new LiveText(
                     new InputOf(
-                        input)).AsString();
+                        input)).ToString();
             }
 
             Assert.False(input.CanRead,
@@ -136,7 +136,7 @@ namespace Yaapii.Atoms.IO.Tests
                             new Uri(Path.GetFullPath(path))
                             )
                         ).AsBytes()
-                    ).AsString()
+                    ).ToString()
                 );
         }
 
@@ -147,7 +147,7 @@ namespace Yaapii.Atoms.IO.Tests
                 new LiveText(
                     new InputOf(
                         new Url("http://www.google.de"))
-                ).AsString().Contains("<html"),
+                ).ToString().Contains("<html"),
                 "Can't fetch bytes from the URL"
             );
         }
@@ -159,7 +159,7 @@ namespace Yaapii.Atoms.IO.Tests
                     new LiveText(
                         new InputOf(
                             new Uri("http://www.google.de"))
-                    ).AsString().Contains("<html"),
+                    ).ToString().Contains("<html"),
                     "Can't fetch bytes from the URL"
             );
         }
@@ -228,7 +228,7 @@ namespace Yaapii.Atoms.IO.Tests
                             new InputOf(
                                 new StringBuilder(starts).Append(ends)
                             )
-                        ).AsBytes()).AsString() == starts + ends,
+                        ).AsBytes()).ToString() == starts + ends,
                     "can't read from stringbuilder"
                 );
         }
@@ -243,7 +243,7 @@ namespace Yaapii.Atoms.IO.Tests
                                 'H', 'o', 'l', 'd', ' ',
                                 'i', 'n', 'f', 'i', 'n', 'i', 't', 'y'
                             )
-                        ).AsBytes()).AsString() == "Hold infinity",
+                        ).AsBytes()).ToString() == "Hold infinity",
                     "Can't read array of chars.");
         }
 
@@ -260,7 +260,7 @@ namespace Yaapii.Atoms.IO.Tests
                             }
                         )
                     ).AsBytes()
-                ).AsString() == "O que sera que sera",
+                ).ToString() == "O que sera que sera",
                 "Can't read array of encoded chars."
             );
         }
@@ -275,7 +275,7 @@ namespace Yaapii.Atoms.IO.Tests
                         new StreamReader(
                             new InputOf(source).Stream())
                     )
-                ).AsString() == source,
+                ).ToString() == source,
                 "Can't read string through a reader"
             );
         }
@@ -290,7 +290,7 @@ namespace Yaapii.Atoms.IO.Tests
                             new StreamReader(
                                 new InputOf(source).Stream()),
                             Encoding.UTF8)
-                ).AsString() == source,
+                ).ToString() == source,
                 "Can't read encoded string through a reader"
             );
         }

--- a/tests/Yaapii.Atoms.Tests/IO/InputStreamOfTest.cs
+++ b/tests/Yaapii.Atoms.Tests/IO/InputStreamOfTest.cs
@@ -48,7 +48,7 @@ namespace Yaapii.Atoms.IO.Tests
                         new InputOf(
                             new InputStreamOf(
                                 new Uri(path))))
-                ).AsString() == content,
+                ).ToString() == content,
                 "Can't read file content");
 
         }
@@ -63,7 +63,7 @@ namespace Yaapii.Atoms.IO.Tests
                         new InputStreamOf(
                             new StreamReader(
                                 new InputOf(content).Stream())))
-                ).AsString() == content);
+                ).ToString() == content);
         }
 
         [Fact]
@@ -79,7 +79,7 @@ namespace Yaapii.Atoms.IO.Tests
                             1
                         )
                     )
-                ).AsString() == content,
+                ).ToString() == content,
                 "Can't read from reader through small buffer"
             );
         }
@@ -113,7 +113,7 @@ namespace Yaapii.Atoms.IO.Tests
                         new InputOf(
                             new InputStreamOf(
                                 new Uri(path))))
-                ).AsString() == content,
+                ).ToString() == content,
                 "Can't read file content"
             );
         }

--- a/tests/Yaapii.Atoms.Tests/IO/InputWithFallbackTest.cs
+++ b/tests/Yaapii.Atoms.Tests/IO/InputWithFallbackTest.cs
@@ -40,7 +40,7 @@ namespace Yaapii.Atoms.IO.Tests
                         ),
                         new InputOf("hello, world!")
                     )
-                ).AsString().EndsWith("world!"),
+                ).ToString().EndsWith("world!"),
                 "Can't read alternative source"
             );
         }

--- a/tests/Yaapii.Atoms.Tests/IO/Md5DigestOfTest.cs
+++ b/tests/Yaapii.Atoms.Tests/IO/Md5DigestOfTest.cs
@@ -39,7 +39,7 @@ namespace Yaapii.Atoms.IO.Tests
                 "d41d8cd98f00b204e9800998ecf8427e",
                 new HexOf(
                     new Md5DigestOf(new InputOf(string.Empty))
-                ).AsString()
+                ).ToString()
            );
         }
 
@@ -50,7 +50,7 @@ namespace Yaapii.Atoms.IO.Tests
                 "ed076287532e86365e841e92bfc50d8c",
                 new HexOf(
                     new Md5DigestOf(new InputOf("Hello World!"))
-                ).AsString()
+                ).ToString()
             );
         }
 
@@ -66,7 +66,7 @@ namespace Yaapii.Atoms.IO.Tests
                             this.GetType()
                         )
                     )
-                ).AsString()
+                ).ToString()
             );
         }
     }

--- a/tests/Yaapii.Atoms.Tests/IO/OutputToTest.cs
+++ b/tests/Yaapii.Atoms.Tests/IO/OutputToTest.cs
@@ -51,7 +51,7 @@ namespace Yaapii.Atoms.IO.Tests
                 new LiveText(
                     new InputAsBytes(
                         new InputOf(new Uri(file))))
-                .AsString() == content,
+                .ToString() == content,
                 "Can't write path content");
         }
 
@@ -78,7 +78,7 @@ namespace Yaapii.Atoms.IO.Tests
                         new InputOf(file)
                     )
                 )
-                .AsString() == txt,
+                .ToString() == txt,
                 "Can't write file content"
             );
         }

--- a/tests/Yaapii.Atoms.Tests/IO/ReaderOfTest.cs
+++ b/tests/Yaapii.Atoms.Tests/IO/ReaderOfTest.cs
@@ -50,7 +50,7 @@ namespace Yaapii.Atoms.IO.Tests
                     new InputOf(
                         new ReaderOf(
                             new Uri(path)))
-                ).AsString() == content,
+                ).ToString() == content,
                 "can't read data from file");
         }
 

--- a/tests/Yaapii.Atoms.Tests/IO/ResourceOfTest.cs
+++ b/tests/Yaapii.Atoms.Tests/IO/ResourceOfTest.cs
@@ -35,7 +35,7 @@ namespace Yaapii.Atoms.IO.Tests
                 "Hello from Embedded!",
                 new LiveText(
                     new ResourceOf("IO/Resources/test.txt", Assembly.GetExecutingAssembly())
-                ).AsString()
+                ).ToString()
             );
         }
 
@@ -46,7 +46,7 @@ namespace Yaapii.Atoms.IO.Tests
                 "Hello from Embedded!",
                 new LiveText(
                     new ResourceOf("IO/Resources/test.txt", this.GetType())
-                ).AsString()
+                ).ToString()
             );
         }
 
@@ -61,7 +61,7 @@ namespace Yaapii.Atoms.IO.Tests
                     new ResourceOf(
                         name,
                         this.GetType())
-                ).AsString()
+                ).ToString()
             );
         }
     }

--- a/tests/Yaapii.Atoms.Tests/IO/Sha1DigestOfTest.cs
+++ b/tests/Yaapii.Atoms.Tests/IO/Sha1DigestOfTest.cs
@@ -39,7 +39,7 @@ namespace Yaapii.Atoms.IO.Tests
                 "da39a3ee5e6b4b0d3255bfef95601890afd80709",
                 new HexOf(
                     new Sha1DigestOf(new InputOf(string.Empty))
-                ).AsString()
+                ).ToString()
            );
         }
 
@@ -50,7 +50,7 @@ namespace Yaapii.Atoms.IO.Tests
                 "2ef7bde608ce5404e97d5f042f95f89f1c232871",
                 new HexOf(
                     new Sha1DigestOf(new InputOf("Hello World!"))
-                ).AsString()
+                ).ToString()
             );
         }
 
@@ -66,7 +66,7 @@ namespace Yaapii.Atoms.IO.Tests
                             this.GetType()
                         )
                     )
-                ).AsString()
+                ).ToString()
             );
         }
     }

--- a/tests/Yaapii.Atoms.Tests/IO/Sha256DigestOfTest.cs
+++ b/tests/Yaapii.Atoms.Tests/IO/Sha256DigestOfTest.cs
@@ -39,7 +39,7 @@ namespace Yaapii.Atoms.IO.Tests
                 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                 new HexOf(
                     new Sha256DigestOf(new InputOf(string.Empty))
-                ).AsString()
+                ).ToString()
            );
         }
 
@@ -50,7 +50,7 @@ namespace Yaapii.Atoms.IO.Tests
                 "7f83b1657ff1fc53b92dc18148a1d65dfc2d4b1fa3d677284addd200126d9069",
                 new HexOf(
                     new Sha256DigestOf(new InputOf("Hello World!"))
-                ).AsString()
+                ).ToString()
             );
         }
 
@@ -66,7 +66,7 @@ namespace Yaapii.Atoms.IO.Tests
                             this.GetType()
                         )
                     )
-                ).AsString()
+                ).ToString()
             );
         }
     }

--- a/tests/Yaapii.Atoms.Tests/IO/StickyInputTest.cs
+++ b/tests/Yaapii.Atoms.Tests/IO/StickyInputTest.cs
@@ -83,7 +83,7 @@ namespace Yaapii.Atoms.IO.Tests
                             new Url("http://www.google.de")
                         )
                     )
-                ).AsString()
+                ).ToString()
             );
         }
 

--- a/tests/Yaapii.Atoms.Tests/IO/TeeInputTest.cs
+++ b/tests/Yaapii.Atoms.Tests/IO/TeeInputTest.cs
@@ -95,7 +95,7 @@ namespace Yaapii.Atoms.IO.Tests
                         new InputOf(content),
                         new OutputTo(baos)
                     )
-                ).AsString() == Encoding.UTF8.GetString(baos.ToArray())
+                ).ToString() == Encoding.UTF8.GetString(baos.ToArray())
             );
         }
 
@@ -118,10 +118,10 @@ namespace Yaapii.Atoms.IO.Tests
                             new OutputTo(new Uri(path))
                         )
                     )
-                ).AsString();
+                ).ToString();
 
             Assert.True(
-                str == new LiveText(new InputOf(new Uri(path))).AsString(),
+                str == new LiveText(new InputOf(new Uri(path))).ToString(),
                 "Can't copy Input to File and return content");
         }
     }

--- a/tests/Yaapii.Atoms.Tests/IO/TeeOutputTest.cs
+++ b/tests/Yaapii.Atoms.Tests/IO/TeeOutputTest.cs
@@ -46,7 +46,7 @@ namespace Yaapii.Atoms.IO.Tests
                             new OutputTo(copy)
                         )
                     )
-                ).AsString() == Encoding.UTF8.GetString(copy.ToArray()),
+                ).ToString() == Encoding.UTF8.GetString(copy.ToArray()),
                 "Can't copy Output to Output and return Input");
         }
     }

--- a/tests/Yaapii.Atoms.Tests/IO/TeeReaderTest.cs
+++ b/tests/Yaapii.Atoms.Tests/IO/TeeReaderTest.cs
@@ -50,7 +50,7 @@ namespace Yaapii.Atoms.IO.Tests
                 new LiveText(
                     new InputOf(
                         new ReaderOf(baos.ToArray()))
-                ).AsString().CompareTo(content) == 0,
+                ).ToString().CompareTo(content) == 0,
                 "Can't read content");
         }
 

--- a/tests/Yaapii.Atoms.Tests/IO/UnZippedFileTest.cs
+++ b/tests/Yaapii.Atoms.Tests/IO/UnZippedFileTest.cs
@@ -61,7 +61,7 @@ namespace Yaapii.Atoms.IO.Tests
                        ),
                        fileName
                    )
-                ).AsString()
+                ).ToString()
             ); 
         }
 

--- a/tests/Yaapii.Atoms.Tests/IO/WriterToTest.cs
+++ b/tests/Yaapii.Atoms.Tests/IO/WriterToTest.cs
@@ -51,7 +51,7 @@ namespace Yaapii.Atoms.IO.Tests
                                     output
                                 )
                             )
-                        ).AsString();
+                        ).ToString();
             }
 
             Assert.True(
@@ -59,7 +59,7 @@ namespace Yaapii.Atoms.IO.Tests
                     new InputAsBytes(
                         new InputOf(uri)
                     )
-                ).AsString().CompareTo(s) == 0 //.CompareTo is needed because Streamwriter writes UTF8 _with_ BOM, which results in a different encoding.
+                ).ToString().CompareTo(s) == 0 //.CompareTo is needed because Streamwriter writes UTF8 _with_ BOM, which results in a different encoding.
             );
         }
     }

--- a/tests/Yaapii.Atoms.Tests/Lists/MappedTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Lists/MappedTest.cs
@@ -40,7 +40,7 @@ namespace Yaapii.Atoms.List.Tests
                         new ListOf<string>("hello", "world", "damn")
                     ),
                     0
-                ).Value().AsString()
+                ).Value().ToString()
             );
         }
 

--- a/tests/Yaapii.Atoms.Tests/Scalar/AndTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Scalar/AndTest.cs
@@ -88,7 +88,7 @@ namespace Yaapii.Atoms.Scalar.Tests
                 ).Value() == true);
 
             Assert.True(
-                new Joined(" ", list).AsString() == "hello world",
+                new Joined(" ", list).ToString() == "hello world",
             "Can't iterate a list with a procedure");
         }
 

--- a/tests/Yaapii.Atoms.Tests/Text/Base64TextTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/Base64TextTest.cs
@@ -46,7 +46,7 @@ namespace Yaapii.Atoms.Text.Tests
                                     new LiveText(text)
                                 )
                             )
-                        ).AsString(),
+                        ).ToString(),
                         new OutputTo(new Uri(tempFile.Value()))
                     )
                 ).Value();

--- a/tests/Yaapii.Atoms.Tests/Text/ComparableTests.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/ComparableTests.cs
@@ -60,7 +60,7 @@ namespace Yaapii.Atoms.Text.Tests
             Assert.True(
                 new Comparable(
                     new LiveText("Timm")
-                ).AsString()
+                ).ToString()
                 == "Timm"
             );
         }

--- a/tests/Yaapii.Atoms.Tests/Text/FormattedTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/FormattedTest.cs
@@ -35,7 +35,7 @@ namespace Yaapii.Atoms.Text.Tests
             Assert.True(
                 new Formatted(
                     "{0} Formatted {1}", 1, "text"
-                ).AsString().Contains("1 Formatted text"),
+                ).ToString().Contains("1 Formatted text"),
                 "Can't format a text");
         }
 
@@ -47,7 +47,7 @@ namespace Yaapii.Atoms.Text.Tests
                     new LiveText("{0}. Number as {1}"),
                     1,
                     "string"
-                ).AsString().Contains("1. Number as string"),
+                ).ToString().Contains("1. Number as string"),
                 "Can't format a text with objects");
         }
 
@@ -58,7 +58,7 @@ namespace Yaapii.Atoms.Text.Tests
                 () => new Formatted(
                     new LiveText("Formatted { {0} }"),
                     new string[] {"invalid" }
-            ).AsString());
+            ).ToString());
         }
 
         [Fact]
@@ -68,7 +68,7 @@ namespace Yaapii.Atoms.Text.Tests
                 new Formatted(
                     new TextOf("{0}. Formatted as {1}"),
                     new String[] { "1", "txt" }
-                ).AsString() == "1. Formatted as txt"
+                ).ToString() == "1. Formatted as txt"
             );
         }
 
@@ -78,7 +78,7 @@ namespace Yaapii.Atoms.Text.Tests
             Assert.True(
                 new Formatted(
                     "{0:0.0}", new CultureInfo("de-DE"), 1234567890
-                ).AsString() == "1234567890,0",
+                ).ToString() == "1234567890,0",
                 "Can't format a text with Locale");
         }
 
@@ -91,7 +91,7 @@ namespace Yaapii.Atoms.Text.Tests
                     "{0} is a {1} test",
                     new LiveText("This"),
                     new LiveText("FormattedText")
-                ).AsString()
+                ).ToString()
             );
                     
         }

--- a/tests/Yaapii.Atoms.Tests/Text/HexOfTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/HexOfTest.cs
@@ -38,7 +38,7 @@ namespace Yaapii.Atoms.Text.Tests
         {
             Assert.Equal(
                 string.Empty,
-                new HexOf(new BytesOf(string.Empty.ToCharArray())).AsString()
+                new HexOf(new BytesOf(string.Empty.ToCharArray())).ToString()
             );
         }
 
@@ -49,7 +49,7 @@ namespace Yaapii.Atoms.Text.Tests
                 "5768617427732075702c20d0b4d180d183d0b33f",
                 new HexOf(
                     new BytesOf("What's up, друг?")
-                ).AsString()
+                ).ToString()
             );
         }
     }

--- a/tests/Yaapii.Atoms.Tests/Text/JoinedTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/JoinedTest.cs
@@ -34,7 +34,7 @@ namespace Yaapii.Atoms.Text.Tests
                     " ", 
                     "hello", 
                     "world"
-                ).AsString() == "hello world"
+                ).ToString() == "hello world"
             );
         }
 
@@ -46,7 +46,7 @@ namespace Yaapii.Atoms.Text.Tests
                     new LiveText(" "),
                     new LiveText("foo"),
                     new LiveText("bar")
-                ).AsString() == "foo bar"
+                ).ToString() == "foo bar"
             );
         }
     }

--- a/tests/Yaapii.Atoms.Tests/Text/LowerTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/LowerTest.cs
@@ -32,7 +32,7 @@ namespace Yaapii.Atoms.Text.Tests
             Assert.True(
                 new Lower(
                     new LiveText("HelLo!")
-                ).AsString() == "hello!"
+                ).ToString() == "hello!"
             );
         }
     }

--- a/tests/Yaapii.Atoms.Tests/Text/NormalizedTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/NormalizedTest.cs
@@ -34,7 +34,7 @@ namespace Yaapii.Atoms.Text.Tests
         public void NormalizesText()
         {
             Assert.True(
-            new Normalized(" \t hello  \t\tworld   \t").AsString() == "hello world",
+            new Normalized(" \t hello  \t\tworld   \t").ToString() == "hello world",
             "Can't normalize a text");
         }
     }

--- a/tests/Yaapii.Atoms.Tests/Text/NotNullTests.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/NotNullTests.cs
@@ -32,7 +32,7 @@ namespace Yaapii.Atoms.Text.Tests
 		{
 			IText s = null;
 			Assert.Throws<IOException>(
-				()=>new NotNull(s).AsString()
+				()=>new NotNull(s).ToString()
 			);
 		}
     }

--- a/tests/Yaapii.Atoms.Tests/Text/ParagraphTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/ParagraphTest.cs
@@ -12,7 +12,7 @@ namespace Yaapii.Atoms.Text.Tests
         public void BuildsWithParamsString()
         {
             var p = new Paragraph("a", "b", "c");
-            Assert.Equal("a\nb\nc".Replace("\n", Environment.NewLine), p.AsString());
+            Assert.Equal("a\nb\nc".Replace("\n", Environment.NewLine), p.ToString());
         }
 
         [Fact]
@@ -24,7 +24,7 @@ namespace Yaapii.Atoms.Text.Tests
                     new LiveText("b"),
                     new LiveText("c")
                 ));
-            Assert.Equal("a\nb\nc".Replace("\n", Environment.NewLine), p.AsString());
+            Assert.Equal("a\nb\nc".Replace("\n", Environment.NewLine), p.ToString());
         }
 
         [Fact]
@@ -35,7 +35,7 @@ namespace Yaapii.Atoms.Text.Tests
                 new string[] { "I", "was", "here" },
                 "foo", "bar"
             );
-            Assert.Equal("Hello\nWorld\nI\nwas\nhere\nfoo\nbar".Replace("\n", Environment.NewLine), p.AsString());
+            Assert.Equal("Hello\nWorld\nI\nwas\nhere\nfoo\nbar".Replace("\n", Environment.NewLine), p.ToString());
         }
 
         [Fact]
@@ -46,7 +46,7 @@ namespace Yaapii.Atoms.Text.Tests
                 new string[] { "I", "was", "here" },
                 new LiveText("foo"), new LiveText("bar")
             );
-            Assert.Equal("Hello\nWorld\nI\nwas\nhere\nfoo\nbar".Replace("\n", Environment.NewLine), p.AsString());
+            Assert.Equal("Hello\nWorld\nI\nwas\nhere\nfoo\nbar".Replace("\n", Environment.NewLine), p.ToString());
         }
     }
 }

--- a/tests/Yaapii.Atoms.Tests/Text/RepeatedTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/RepeatedTest.cs
@@ -30,7 +30,7 @@ namespace Yaapii.Atoms.Text.Tests
         public void RepeatsWordsText()
         {
             Assert.True(
-                new Repeated("hello", 2).AsString() == "hellohello",
+                new Repeated("hello", 2).ToString() == "hellohello",
                 "Can't repeat a text");
         }
 
@@ -38,7 +38,7 @@ namespace Yaapii.Atoms.Text.Tests
         public void RepeatsCharText()
         {
             Assert.True(
-                new Repeated("A", 5).AsString() == "AAAAA",
+                new Repeated("A", 5).ToString() == "AAAAA",
                 "Can't repeat a char");
         }
     }

--- a/tests/Yaapii.Atoms.Tests/Text/ReplacedTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/ReplacedTest.cs
@@ -34,7 +34,7 @@ namespace Yaapii.Atoms.Text.Tests
                 new Replaced(
                     new LiveText("Hello!"),
                     "ello", "i"
-                ).AsString() == "Hi!",
+                ).ToString() == "Hi!",
                 "Can't replace a text");
         }
 
@@ -46,7 +46,7 @@ namespace Yaapii.Atoms.Text.Tests
                 new Replaced(
                     new LiveText(text),
                     "xyz", "i"
-                ).AsString() == text,
+                ).ToString() == text,
                 "Replace a text abnormally");
         }
 
@@ -58,7 +58,7 @@ namespace Yaapii.Atoms.Text.Tests
                     new LiveText("one cat, two cats, three cats"),
                     "cat",
                     "dog"
-                ).AsString() == "one dog, two dogs, three dogs",
+                ).ToString() == "one dog, two dogs, three dogs",
                 "Can't replace a text with multiple needle occurrences");
         }
     }

--- a/tests/Yaapii.Atoms.Tests/Text/ReversedTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/ReversedTest.cs
@@ -32,7 +32,7 @@ namespace Yaapii.Atoms.Text.Tests
             Assert.True(
                 new Reversed(
                     new LiveText("Hello!")
-                ).AsString() == "!olleH",
+                ).ToString() == "!olleH",
                 "Can't reverse a text");
         }
 
@@ -42,7 +42,7 @@ namespace Yaapii.Atoms.Text.Tests
             Assert.True(
                 new Reversed(
                     new LiveText("")
-                ).AsString() == "",
+                ).ToString() == "",
                 "Can't reverse empty text");
         }
     }

--- a/tests/Yaapii.Atoms.Tests/Text/RotatedTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/RotatedTest.cs
@@ -32,7 +32,7 @@ namespace Yaapii.Atoms.Text.Tests
             Assert.True(
                 new Rotated(
                     new LiveText("Hello!"), 2
-                ).AsString() == "o!Hell"
+                ).ToString() == "o!Hell"
             );
         }
 
@@ -42,7 +42,7 @@ namespace Yaapii.Atoms.Text.Tests
             Assert.True(
                 new Rotated(
                     new LiveText("Hi!"), -1
-                ).AsString() == "i!H"
+                ).ToString() == "i!H"
             );
         }
 
@@ -53,7 +53,7 @@ namespace Yaapii.Atoms.Text.Tests
             Assert.True(
                 new Rotated(
                     new LiveText(nonrotate), 0
-                ).AsString() == nonrotate
+                ).ToString() == nonrotate
             );
         }
 
@@ -64,7 +64,7 @@ namespace Yaapii.Atoms.Text.Tests
             Assert.True(
                 new Rotated(
                     new LiveText(nonrotate), nonrotate.Length
-                ).AsString() == nonrotate,
+                ).ToString() == nonrotate,
                 "Can't rotate text shift mod zero");
         }
 
@@ -74,7 +74,7 @@ namespace Yaapii.Atoms.Text.Tests
             Assert.True(
                 new Rotated(
                     new LiveText(""), 2
-                ).AsString() == ""
+                ).ToString() == ""
             );
         }
     }

--- a/tests/Yaapii.Atoms.Tests/Text/StrictTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/StrictTest.cs
@@ -10,7 +10,7 @@ namespace Yaapii.Atoms.Text.Tests
         public void Throws()
         {
             Assert.Throws<ArgumentException>(() =>
-                new Strict("not valid", "valid", "also valid").AsString()
+                new Strict("not valid", "valid", "also valid").ToString()
             );
         }
 
@@ -20,7 +20,7 @@ namespace Yaapii.Atoms.Text.Tests
             var expected = "valid";
             Assert.Equal(
                 expected,
-                new Strict(expected, "not valid", "also not", "valid", "ending").AsString()
+                new Strict(expected, "not valid", "also not", "valid", "ending").ToString()
             );
         }
 
@@ -30,7 +30,7 @@ namespace Yaapii.Atoms.Text.Tests
             var expected = "LargeValid";
             Assert.Equal(
                 expected,
-                new Strict(expected, "not valid", "also not", "LargeValid", "ending").AsString()
+                new Strict(expected, "not valid", "also not", "LargeValid", "ending").ToString()
             );
         }
 
@@ -39,7 +39,7 @@ namespace Yaapii.Atoms.Text.Tests
         {
             Assert.Throws<ArgumentException>(
                 () =>
-                new Strict("valid", false, "not valid", "also not", "largeValid", "ending").AsString()
+                new Strict("valid", false, "not valid", "also not", "largeValid", "ending").ToString()
             );
         }
 
@@ -51,7 +51,7 @@ namespace Yaapii.Atoms.Text.Tests
                 expected,
                 new Strict(expected,
                     new ManyOf("NotValid", expected)
-                ).AsString()
+                ).ToString()
             );
         }
 
@@ -67,8 +67,8 @@ namespace Yaapii.Atoms.Text.Tests
                         new TextOf(expected)
                     )
                 );
-            text.AsString();
-            text.AsString();
+            text.ToString();
+            text.ToString();
             Assert.Equal(
                 1,
                 counter
@@ -87,7 +87,7 @@ namespace Yaapii.Atoms.Text.Tests
                         new TextOf("Not Valid"),
                         new TextOf(expected)
                     )
-                ).AsString()
+                ).ToString()
             );
         }
 
@@ -104,7 +104,7 @@ namespace Yaapii.Atoms.Text.Tests
                         "As well not valid",
                         "ExpEcteD"
                     )
-                ).AsString()
+                ).ToString()
             );
         }
 
@@ -119,7 +119,7 @@ namespace Yaapii.Atoms.Text.Tests
                     "Not Valid",
                     "As well not valid",
                     "ExpEcteD"
-                ).AsString()
+                ).ToString()
             );
         }
     }

--- a/tests/Yaapii.Atoms.Tests/Text/SyncedTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/SyncedTest.cs
@@ -34,12 +34,12 @@ namespace Yaapii.Atoms.Text.Tests
             var check = 0;
             var text = new Synced(
                 new LiveText(
-                    () => new TextOf(check++).AsString()
+                    () => new TextOf(check++).ToString()
                 )
             );
 
             var max = Environment.ProcessorCount << 8;
-            Parallel.For(0, max, (nr) => text.AsString());
+            Parallel.For(0, max, (nr) => text.ToString());
 
             Assert.Equal(
                 max, check

--- a/tests/Yaapii.Atoms.Tests/Text/TextBase64Tests.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/TextBase64Tests.cs
@@ -46,7 +46,7 @@ namespace Yaapii.Atoms.Text.Tests
                                     new LiveText(text)
                                 )
                             )
-                        ).AsString(),
+                        ).ToString(),
                         new OutputTo(new Uri(tempFile.Value()))
                     )
                 ).Value();
@@ -78,8 +78,8 @@ namespace Yaapii.Atoms.Text.Tests
                             new LiveText(text)
                         )
                     )
-                ).AsString(),
-                new TextBase64(text).AsString()
+                ).ToString(),
+                new TextBase64(text).ToString()
             );
         }
     }

--- a/tests/Yaapii.Atoms.Tests/Text/TextOfTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/TextOfTest.cs
@@ -51,7 +51,7 @@ namespace Yaapii.Atoms.Text.Tests
                         new TextOf(
                             path,
                             Encoding.BigEndianUnicode
-                        ).AsString() == content,
+                        ).ToString() == content,
                         "Can't read text from Input");
                 },
                 path
@@ -72,7 +72,7 @@ namespace Yaapii.Atoms.Text.Tests
                     Assert.True(
                         new TextOf(
                             path
-                        ).AsString() == content,
+                        ).ToString() == content,
                         "Can't read text from Input");
                 },
                 path
@@ -94,7 +94,7 @@ namespace Yaapii.Atoms.Text.Tests
                         new TextOf(
                             new FileInfo(path.AbsolutePath),
                             Encoding.BigEndianUnicode
-                        ).AsString() == content,
+                        ).ToString() == content,
                         "Can't read text from Input");
                 },
                 path
@@ -116,7 +116,7 @@ namespace Yaapii.Atoms.Text.Tests
                         new TextOf(
                             new FileInfo(path.AbsolutePath),
                             Encoding.UTF8
-                        ).AsString() == content,
+                        ).ToString() == content,
                         "Can't read text from Input");
                 },
                 path
@@ -132,7 +132,7 @@ namespace Yaapii.Atoms.Text.Tests
                 content,
                 new TextOf(
                     new MemoryStream(new BytesOf(content).AsBytes())
-                ).AsString()
+                ).ToString()
             );
         }
 
@@ -145,7 +145,7 @@ namespace Yaapii.Atoms.Text.Tests
             new TextOf(
                 new InputOf(content),
                 Encoding.UTF8
-            ).AsString() == content,
+            ).ToString() == content,
             "Can't read text from Input");
         }
 
@@ -156,7 +156,7 @@ namespace Yaapii.Atoms.Text.Tests
             Assert.True(
                 new TextOf(
                     new InputOf(content)
-                ).AsString() == content,
+                ).ToString() == content,
                 "Can't read text from Input with default charset");
         }
 
@@ -167,7 +167,7 @@ namespace Yaapii.Atoms.Text.Tests
             var content = doub.ToString(CultureInfo.InvariantCulture);
 
             Assert.True(
-                new LiveText(doub).AsString() == content
+                new LiveText(doub).ToString() == content
             );
         }
 
@@ -181,7 +181,7 @@ namespace Yaapii.Atoms.Text.Tests
             Assert.True(
                     new TextOf(doub,
                    inf
-                    ).AsString() == content,
+                    ).ToString() == content,
                     "Can't read text from double with format");
         }
 
@@ -193,7 +193,7 @@ namespace Yaapii.Atoms.Text.Tests
 
             Assert.True(
                     new TextOf(doub
-                    ).AsString() == content,
+                    ).ToString() == content,
                     "Can't read text from float");
         }
 
@@ -208,7 +208,7 @@ namespace Yaapii.Atoms.Text.Tests
             Assert.True(
                     new TextOf(doub,
                    inf
-                    ).AsString() == content,
+                    ).ToString() == content,
                     "Can't read text with format from float");
         }
 
@@ -222,7 +222,7 @@ namespace Yaapii.Atoms.Text.Tests
                         new InputOf(content),
                         2,
                         Encoding.UTF8
-                    ).AsString() == content,
+                    ).ToString() == content,
                     "Can't read text with a small reading buffer");
         }
 
@@ -235,7 +235,7 @@ namespace Yaapii.Atoms.Text.Tests
                     new TextOf(
                         new InputOf(content),
                         2
-                    ).AsString() == content,
+                    ).ToString() == content,
                     "Can't read text with a small reading buffer and default charset");
         }
 
@@ -247,7 +247,7 @@ namespace Yaapii.Atoms.Text.Tests
             new TextOf(
                 new StringReader(source),
                 Encoding.UTF8
-            ).AsString() == Encoding.UTF8.GetString(new BytesOf(source).AsBytes()),
+            ).ToString() == Encoding.UTF8.GetString(new BytesOf(source).AsBytes()),
             "Can't read string through a reader");
         }
 
@@ -257,7 +257,7 @@ namespace Yaapii.Atoms.Text.Tests
         {
             String source = "hello, друг! with default encoding";
             Assert.True(
-                new TextOf(new StringReader(source)).AsString() ==
+                new TextOf(new StringReader(source)).ToString() ==
                     Encoding.UTF8.GetString(new BytesOf(source).AsBytes()),
                 "Can't read string with default encoding through a reader");
         }
@@ -269,7 +269,7 @@ namespace Yaapii.Atoms.Text.Tests
                     new TextOf(
                         'O', ' ', 'q', 'u', 'e', ' ', 's', 'e', 'r', 'a',
                         ' ', 'q', 'u', 'e', ' ', 's', 'e', 'r', 'a'
-                    ).AsString().CompareTo("O que sera que sera") == 0,
+                    ).ToString().CompareTo("O que sera que sera") == 0,
                     "Can't read array of encoded chars into text.");
         }
 
@@ -280,7 +280,7 @@ namespace Yaapii.Atoms.Text.Tests
             Assert.True(
                 new TextOf(
                     bytes
-                ).AsString().CompareTo(Encoding.UTF8.GetString(bytes)) == 0,
+                ).ToString().CompareTo(Encoding.UTF8.GetString(bytes)) == 0,
                 "Can't read array of bytes");
         }
 
@@ -292,7 +292,7 @@ namespace Yaapii.Atoms.Text.Tests
                 new TextOf(
                     new BytesOf(bytes),
                     Encoding.ASCII
-                ).AsString().CompareTo(Encoding.ASCII.GetString(bytes)) == 0,
+                ).ToString().CompareTo(Encoding.ASCII.GetString(bytes)) == 0,
                 "Can't read array of bytes");
         }
 
@@ -314,7 +314,7 @@ namespace Yaapii.Atoms.Text.Tests
             Assert.True(
                     new TextOf(
                         new StringBuilder(starts).Append(ends)
-                    ).AsString() == starts + ends,
+                    ).ToString() == starts + ends,
                     "Can't process a string builder");
         }
 
@@ -326,7 +326,7 @@ namespace Yaapii.Atoms.Text.Tests
                     new IOException(
                         "It doesn't work at all"
                     )
-                ).AsString().Contains("It doesn't work at all"),
+                ).ToString().Contains("It doesn't work at all"),
                 "Can't print exception stacktrace");
         }
 
@@ -338,7 +338,7 @@ namespace Yaapii.Atoms.Text.Tests
             Assert.True(
                 new TextOf(
                     value
-                ).AsString() == text,
+                ).ToString() == text,
                 "Can't read long into text"
             );
         }

--- a/tests/Yaapii.Atoms.Tests/Text/TrimmedLeftTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/TrimmedLeftTest.cs
@@ -31,7 +31,7 @@ namespace Yaapii.Atoms.Text.Tests
         public void TrimsWhitespaceEscapeSequences()
         {
             Assert.True(
-                new TrimmedLeft(new LiveText("   \b \f \n \r \t \v   ")).AsString() == string.Empty
+                new TrimmedLeft(new LiveText("   \b \f \n \r \t \v   ")).ToString() == string.Empty
             );
         }
 
@@ -42,7 +42,7 @@ namespace Yaapii.Atoms.Text.Tests
                 "Hello! \t \b  ",
                 new TrimmedLeft(
                     " \b   \t      Hello! \t \b  "
-                ).AsString()
+                ).ToString()
             );
         }
 
@@ -53,7 +53,7 @@ namespace Yaapii.Atoms.Text.Tests
                 "Hello! \t \b  ",
                 new TrimmedLeft(
                     new LiveText(" \b   \t      Hello! \t \b  ")
-                ).AsString()
+                ).ToString()
             );
         }
 
@@ -65,7 +65,7 @@ namespace Yaapii.Atoms.Text.Tests
                 new TrimmedLeft(
                     " \b   \t      Hello! \t \b  ", 
                     new char[] { '\b', '\t', ' ', 'H', 'o' }
-                ).AsString()
+                ).ToString()
             );
         }
 
@@ -77,7 +77,7 @@ namespace Yaapii.Atoms.Text.Tests
                 new TrimmedLeft(
                     new LiveText(" \b   \t      Hello! \t \b  "), 
                     new char[] { '\b', '\t', ' ', 'H', 'o' }
-                ).AsString()
+                ).ToString()
             );
         }
 
@@ -89,7 +89,7 @@ namespace Yaapii.Atoms.Text.Tests
                 new TrimmedLeft(
                     new LiveText(" \b   \t      Hello! \t \b  "), 
                     new Live<char[]>(() => new char[] { '\b', '\t', ' ', 'H', 'o' })
-                ).AsString()
+                ).ToString()
             );
         }
 
@@ -100,7 +100,7 @@ namespace Yaapii.Atoms.Text.Tests
                 "ello! \t \b   \t      H",
                 new TrimmedLeft(
                     " \b   \t      Hello! \t \b   \t      H", " \b   \t      H"
-                ).AsString()
+                ).ToString()
             );
         }
 
@@ -109,7 +109,7 @@ namespace Yaapii.Atoms.Text.Tests
         {
             Assert.Equal(
                 "ello! \t \b   \t      H",
-                new TrimmedLeft(new LiveText(" \b   \t      Hello! \t \b   \t      H"), " \b   \t      H").AsString()
+                new TrimmedLeft(new LiveText(" \b   \t      Hello! \t \b   \t      H"), " \b   \t      H").ToString()
             );
         }
 
@@ -118,7 +118,7 @@ namespace Yaapii.Atoms.Text.Tests
         {
             Assert.Equal(
                 "ello! \t \b   \t      H",
-                new TrimmedLeft(" \b   \t      Hello! \t \b   \t      H", new LiveText(" \b   \t      H")).AsString()
+                new TrimmedLeft(" \b   \t      Hello! \t \b   \t      H", new LiveText(" \b   \t      H")).ToString()
             );
         }
 
@@ -130,7 +130,7 @@ namespace Yaapii.Atoms.Text.Tests
                 new TrimmedLeft(
                     new LiveText(" \b   \t      Hello! \t \b   \t      H"),
                     new LiveText(" \b   \t      H")
-                ).AsString()
+                ).ToString()
             );
         }
     }

--- a/tests/Yaapii.Atoms.Tests/Text/TrimmedRightTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/TrimmedRightTest.cs
@@ -33,7 +33,7 @@ namespace Yaapii.Atoms.Text.Tests
             Assert.True(
                 new TrimmedRight(
                     new LiveText("   \b \f \n \r \t \v   ")
-                ).AsString() == string.Empty
+                ).ToString() == string.Empty
             );
         }
 
@@ -41,7 +41,7 @@ namespace Yaapii.Atoms.Text.Tests
         public void TrimsString()
         {
             Assert.True(
-                new TrimmedRight(" \b   \t      Hello! \t \b  ").AsString() == " \b   \t      Hello!"
+                new TrimmedRight(" \b   \t      Hello! \t \b  ").ToString() == " \b   \t      Hello!"
             );
         }
 
@@ -51,7 +51,7 @@ namespace Yaapii.Atoms.Text.Tests
             Assert.True(
                 new TrimmedRight(
                     new LiveText(" \b   \t      Hello! \t \b  ")
-                ).AsString() == " \b   \t      Hello!"
+                ).ToString() == " \b   \t      Hello!"
             );
         }
 
@@ -62,7 +62,7 @@ namespace Yaapii.Atoms.Text.Tests
                 new TrimmedRight(
                     " \b   \t      Hello! \t \b  ", 
                     new char[] { '\b', '\t', ' ', 'H', '!', 'o' }
-                ).AsString() == " \b   \t      Hell"
+                ).ToString() == " \b   \t      Hell"
             );
         }
 
@@ -70,7 +70,7 @@ namespace Yaapii.Atoms.Text.Tests
         public void TrimsTextWithCharArray()
         {
             Assert.True(
-                new TrimmedRight(new LiveText(" \b   \t      Hello! \t \b  "), new char[] { '\b', '\t', ' ', 'H', '!', 'o' }).AsString() == " \b   \t      Hell"
+                new TrimmedRight(new LiveText(" \b   \t      Hello! \t \b  "), new char[] { '\b', '\t', ' ', 'H', '!', 'o' }).ToString() == " \b   \t      Hell"
             );
         }
 
@@ -81,7 +81,7 @@ namespace Yaapii.Atoms.Text.Tests
                 new TrimmedRight(
                     new LiveText(" \b   \t      Hello! \t \b  "), 
                     new Live<char[]>(() => new char[] { '\b', '\t', ' ', 'H', '!', 'o' })
-                ).AsString() == " \b   \t      Hell"
+                ).ToString() == " \b   \t      Hell"
             );
         }
 
@@ -89,7 +89,7 @@ namespace Yaapii.Atoms.Text.Tests
         public void RemovesStringFromString()
         {
             Assert.True(
-                new TrimmedRight(" \b   \t      Hello! \t \b   \t      H", " \b   \t      H").AsString() == " \b   \t      Hello! \t"
+                new TrimmedRight(" \b   \t      Hello! \t \b   \t      H", " \b   \t      H").ToString() == " \b   \t      Hello! \t"
             );
         }
 
@@ -98,7 +98,7 @@ namespace Yaapii.Atoms.Text.Tests
         {
             Assert.True(
                 new TrimmedRight(
-                    new LiveText(" \b   \t      Hello! \t \b   \t      H"), " \b   \t      H").AsString() == " \b   \t      Hello! \t"
+                    new LiveText(" \b   \t      Hello! \t \b   \t      H"), " \b   \t      H").ToString() == " \b   \t      Hello! \t"
             );
         }
 
@@ -108,7 +108,7 @@ namespace Yaapii.Atoms.Text.Tests
             Assert.True(
                 new TrimmedRight(" \b   \t      Hello! \t \b   \t      H", 
                     new LiveText(" \b   \t      H")
-                ).AsString() == " \b   \t      Hello! \t"
+                ).ToString() == " \b   \t      Hello! \t"
             );
         }
 
@@ -119,7 +119,7 @@ namespace Yaapii.Atoms.Text.Tests
                 new TrimmedRight(
                     new LiveText(" \b   \t      Hello! \t \b   \t      H"), 
                     new LiveText(" \b   \t      H")
-                ).AsString() == " \b   \t      Hello! \t"
+                ).ToString() == " \b   \t      Hello! \t"
             );
         }
     }

--- a/tests/Yaapii.Atoms.Tests/Text/TrimmedTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/TrimmedTest.cs
@@ -33,7 +33,7 @@ namespace Yaapii.Atoms.Text.Tests
             Assert.True(
                 new Trimmed(
                     new TextOf("   \b \f \n \r \t \v   ")
-                ).AsString() == string.Empty
+                ).ToString() == string.Empty
             );
         }
 
@@ -41,7 +41,7 @@ namespace Yaapii.Atoms.Text.Tests
         public void TrimsString()
         {
             Assert.True(
-                new Trimmed(" \b   \t      Hello! \t \b  ").AsString() == "Hello!"
+                new Trimmed(" \b   \t      Hello! \t \b  ").ToString() == "Hello!"
             );
         }
 
@@ -49,7 +49,7 @@ namespace Yaapii.Atoms.Text.Tests
         public void TrimsText()
         {
             Assert.True(
-                new Trimmed(new LiveText(" \b   \t      Hello! \t \b  ")).AsString() == "Hello!"
+                new Trimmed(new LiveText(" \b   \t      Hello! \t \b  ")).ToString() == "Hello!"
             );
         }
 
@@ -57,7 +57,7 @@ namespace Yaapii.Atoms.Text.Tests
         public void TrimsStringWithCharArray()
         {
             Assert.True(
-                new Trimmed(" \b   \t      Hello! \t \b  ", new char[] { '\b', '\t', ' ', 'H', 'o' }).AsString() == "ello!"
+                new Trimmed(" \b   \t      Hello! \t \b  ", new char[] { '\b', '\t', ' ', 'H', 'o' }).ToString() == "ello!"
             );
         }
 
@@ -65,7 +65,7 @@ namespace Yaapii.Atoms.Text.Tests
         public void TrimsTextWithCharArray()
         {
             Assert.True(
-                new Trimmed(new LiveText(" \b   \t      Hello! \t \b  "), new char[] { '\b', '\t', ' ', 'H', 'o' }).AsString() == "ello!"
+                new Trimmed(new LiveText(" \b   \t      Hello! \t \b  "), new char[] { '\b', '\t', ' ', 'H', 'o' }).ToString() == "ello!"
             );
         }
 
@@ -73,7 +73,7 @@ namespace Yaapii.Atoms.Text.Tests
         public void TrimsTextWithScalar()
         {
             Assert.True(
-                new Trimmed(new LiveText(" \b   \t      Hello! \t \b  "), new Live<char[]>(() => new char[] { '\b', '\t', ' ', 'H', 'o' })).AsString() == "ello!"
+                new Trimmed(new LiveText(" \b   \t      Hello! \t \b  "), new Live<char[]>(() => new char[] { '\b', '\t', ' ', 'H', 'o' })).ToString() == "ello!"
             );
         }
 
@@ -81,7 +81,7 @@ namespace Yaapii.Atoms.Text.Tests
         public void RemovesStringFromString()
         {
             Assert.True(
-                new Trimmed(" \b   \t      Hello! \t \b   \t      H", " \b   \t      H").AsString() == "ello! \t"
+                new Trimmed(" \b   \t      Hello! \t \b   \t      H", " \b   \t      H").ToString() == "ello! \t"
             );
         }
 
@@ -89,7 +89,7 @@ namespace Yaapii.Atoms.Text.Tests
         public void RemovesTextFromString()
         {
             Assert.True(
-                new Trimmed(new LiveText(" \b   \t      Hello! \t \b   \t      H"), " \b   \t      H").AsString() == "ello! \t"
+                new Trimmed(new LiveText(" \b   \t      Hello! \t \b   \t      H"), " \b   \t      H").ToString() == "ello! \t"
             );
         }
 
@@ -97,7 +97,7 @@ namespace Yaapii.Atoms.Text.Tests
         public void RemovesStringFromText()
         {
             Assert.True(
-                new Trimmed(" \b   \t      Hello! \t \b   \t      H", new LiveText(" \b   \t      H")).AsString() == "ello! \t"
+                new Trimmed(" \b   \t      Hello! \t \b   \t      H", new LiveText(" \b   \t      H")).ToString() == "ello! \t"
             );
         }
 
@@ -105,7 +105,7 @@ namespace Yaapii.Atoms.Text.Tests
         public void RemovesTextFromText()
         {
             Assert.True(
-                new Trimmed(new LiveText(" \b   \t      Hello! \t \b   \t      H"), new LiveText(" \b   \t      H")).AsString() == "ello! \t"
+                new Trimmed(new LiveText(" \b   \t      Hello! \t \b   \t      H"), new LiveText(" \b   \t      H")).ToString() == "ello! \t"
             );
         }
     }

--- a/tests/Yaapii.Atoms.Tests/Text/UpperTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Text/UpperTest.cs
@@ -31,7 +31,7 @@ namespace Yaapii.Atoms.Text.Tests
         {
             Assert.Equal(
                 "HELLO!",
-                new Upper(new LiveText("Hello!")).AsString()
+                new Upper(new LiveText("Hello!")).ToString()
             );
         }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
#415 

### What is the new behavior?
IText.AsString is renamed to IText.ToString.
closes #415 

### Does this PR introduce a breaking change? (check one with "x")
- [x] Yes
- [ ] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications
The method AsString from IText is now called ToString.

###  Other information