### PR TITLE
Repair List.Contains(...), change caching behaviour

### DIFF
--- a/src/Yaapii.Atoms/Collection/ArrayListAsCollection.cs
+++ b/src/Yaapii.Atoms/Collection/ArrayListAsCollection.cs
@@ -36,15 +36,15 @@ namespace Yaapii.Atoms.Collection
         /// A ArrayList converted to IList&lt;object&gt;
         /// </summary>
         /// <param name="src">source ArrayList</param>
-        public ArrayListAsCollection(ArrayList src) : base(new ScalarOf<ICollection<object>>(() =>
+        public ArrayListAsCollection(ArrayList src) : base(() =>
             {
                 var blocking = new BlockingCollection<object>();
                 foreach (var lst in src)
                 {
                     new Each<object>(item => blocking.Add(item), lst).Invoke();
                 }
-                return new LiveCollection<object>(blocking.ToArray());
-            }),
+                return blocking.GetConsumingEnumerable().GetEnumerator();
+            },
             false
         )
         { }

--- a/src/Yaapii.Atoms/Collection/LiveCollection.cs
+++ b/src/Yaapii.Atoms/Collection/LiveCollection.cs
@@ -51,15 +51,7 @@ namespace Yaapii.Atoms.Collection
         /// </summary>
         /// <param name="src"></param>
         public LiveCollection(IEnumerable<T> src) : base(
-            () =>
-            {
-                ICollection<T> list = new LinkedList<T>();
-                foreach (T item in src)
-                {
-                    list.Add(item);
-                }
-                return list;
-            },
+            () => src.GetEnumerator(),
             true
         )
         { }

--- a/src/Yaapii.Atoms/Collection/Mapped.cs
+++ b/src/Yaapii.Atoms/Collection/Mapped.cs
@@ -36,38 +36,36 @@ namespace Yaapii.Atoms.Collection
         /// <summary>
         /// ctor
         /// </summary>
-        /// <param name="fnc">mapping function</param>
+        /// <param name="mapping">mapping function</param>
         /// <param name="src">source items</param>
-        public Mapped(Func<In, Out> fnc, params In[] src) : this(fnc, new ManyOf<In>(src))
+        public Mapped(Func<In, Out> mapping, params In[] src) : this(mapping, new ManyOf<In>(src))
         { }
 
         /// <summary>
         /// ctor
         /// </summary>
-        /// <param name="fnc">mapping function</param>
+        /// <param name="mapping">mapping function</param>
         /// <param name="src">source enumerator</param>
-        public Mapped(Func<In, Out> fnc, IEnumerator<In> src) : this(
-            fnc, new ManyOf<In>(src))
+        public Mapped(Func<In, Out> mapping, IEnumerator<In> src) : this(
+            mapping, new ManyOf<In>(src))
         { }
 
         /// <summary>
         /// ctor
         /// </summary>
-        /// <param name="fnc">mapping function</param>
+        /// <param name="mapping">mapping function</param>
         /// <param name="src">source enumerable</param>
-        public Mapped(Func<In, Out> fnc, IEnumerable<In> src) : this(
-            fnc, new LiveCollection<In>(src))
+        public Mapped(Func<In, Out> mapping, IEnumerable<In> src) : this(
+            mapping, new LiveCollection<In>(src))
         { }
 
         /// <summary>
         /// ctor
         /// </summary>
-        /// <param name="fnc">mapping function</param>
+        /// <param name="mapping">mapping function</param>
         /// <param name="src">source collection</param>
-        public Mapped(Func<In, Out> fnc, ICollection<In> src) : base(
-            () => new LiveCollection<Out>(
-                new Enumerable.Mapped<In, Out>(fnc, src)
-            ),
+        public Mapped(Func<In, Out> mapping, ICollection<In> src) : base(() =>
+            new Enumerator.Mapped<In, Out>(src.GetEnumerator(), mapping),
             false
         )
         { }

--- a/src/Yaapii.Atoms/Enumerable/Endless.cs
+++ b/src/Yaapii.Atoms/Enumerable/Endless.cs
@@ -44,7 +44,7 @@ namespace Yaapii.Atoms.Enumerable
             new LiveMany<T>(() =>
                 new Enumerator.Endless<T>(elm)
             ),
-            false
+            true
         )
         { }
     }

--- a/src/Yaapii.Atoms/Enumerable/Filtered.cs
+++ b/src/Yaapii.Atoms/Enumerable/Filtered.cs
@@ -50,7 +50,8 @@ namespace Yaapii.Atoms.Enumerable
                     item2
                 ),
                 items
-            )
+            ),
+            false
         )
         { }
 
@@ -59,12 +60,12 @@ namespace Yaapii.Atoms.Enumerable
         /// </summary>
         /// <param name="src">enumerable to filter</param>
         /// <param name="fnc">filter function</param>
-        public Filtered(Func<T, Boolean> fnc, IEnumerable<T> src) : base(() =>
+        public Filtered(Func<T, Boolean> fnc, IEnumerable<T> src, bool live = false) : base(() =>
             new Enumerator.Filtered<T>(
                 src.GetEnumerator(),
                 fnc
             ),
-            false
+            live
         )
         { }
     }

--- a/src/Yaapii.Atoms/Enumerable/Mapped.cs
+++ b/src/Yaapii.Atoms/Enumerable/Mapped.cs
@@ -42,7 +42,7 @@ namespace Yaapii.Atoms.Enumerable
         /// <param name="src">enumerable to map</param>
         /// <param name="fnc">function used to map</param>
         public Mapped(IFunc<In, Out> fnc, params In[] src) : this(
-            fnc, 
+            fnc,
             new LiveMany<In>(src)
         )
         { }
@@ -53,7 +53,7 @@ namespace Yaapii.Atoms.Enumerable
         /// <param name="src">enumerable to map</param>
         /// <param name="fnc">function used to map</param>
         public Mapped(IBiFunc<In, int, Out> fnc, params In[] src) : this(
-            fnc, 
+            fnc,
             new LiveMany<In>(src)
         )
         { }
@@ -63,9 +63,11 @@ namespace Yaapii.Atoms.Enumerable
         /// </summary>
         /// <param name="src">enumerable to map</param>
         /// <param name="fnc">function used to map</param>
-        public Mapped(Func<In, Out> fnc, IEnumerable<In> src) : this(
+        public Mapped(Func<In, Out> fnc, IEnumerable<In> src, bool live = false) : this(
             (In1, In2) => fnc.Invoke(In1),
-            src)
+            src,
+            live
+        )
         { }
 
         /// <summary>
@@ -73,9 +75,10 @@ namespace Yaapii.Atoms.Enumerable
         /// </summary>
         /// <param name="src">enumerable to map</param>
         /// <param name="fnc">function used to map</param>
-        public Mapped(Func<In, int, Out> fnc, IEnumerable<In> src) : this(
+        public Mapped(Func<In, int, Out> fnc, IEnumerable<In> src, bool live = false) : this(
             new BiFuncOf<In, int, Out>(fnc),
-            src
+            src,
+            live
         )
         { }
 
@@ -84,7 +87,7 @@ namespace Yaapii.Atoms.Enumerable
         /// </summary>
         /// <param name="src">enumerable to map</param>
         /// <param name="fnc">function used to map</param>
-        public Mapped(IFunc<In, Out> fnc, IEnumerable<In> src) : this(new BiFuncOf<In, int, Out>((In1, In2) => fnc.Invoke(In1)), src)
+        public Mapped(IFunc<In, Out> fnc, IEnumerable<In> src, bool live = false) : this(new BiFuncOf<In, int, Out>((In1, In2) => fnc.Invoke(In1)), src, live)
         { }
 
         /// <summary>
@@ -92,12 +95,9 @@ namespace Yaapii.Atoms.Enumerable
         /// </summary>
         /// <param name="src">enumerable to map</param>
         /// <param name="fnc">function used to map</param>
-        public Mapped(IBiFunc<In, int, Out> fnc, IEnumerable<In> src) : base(() =>
-            new LiveMany<Out>(() =>
-                new Enumerator.Mapped<In, Out>(
-                    src.GetEnumerator(), fnc)
-            ),
-            false
+        public Mapped(IBiFunc<In, int, Out> fnc, IEnumerable<In> src, bool live = false) : base(() =>
+            new Enumerator.Mapped<In, Out>(src.GetEnumerator(), fnc),
+            live
         )
         { }
     }

--- a/src/Yaapii.Atoms/Enumerator/Mapped.cs
+++ b/src/Yaapii.Atoms/Enumerator/Mapped.cs
@@ -63,7 +63,8 @@ namespace Yaapii.Atoms.Enumerator
         /// <param name="src">source enumerable</param>
         /// <param name="fnc">mapping function</param>
         public Mapped(IEnumerator<In> src, IBiFunc<In, int, Out> fnc) : this(src,
-        (input, index) => fnc.Invoke(input, index))
+            (input, index) => fnc.Invoke(input, index)
+        )
         { }
 
         /// <summary>

--- a/src/Yaapii.Atoms/Enumerator/Repeated.cs
+++ b/src/Yaapii.Atoms/Enumerator/Repeated.cs
@@ -23,7 +23,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Text;
 using Yaapii.Atoms.Scalar;
 
 #pragma warning disable Immutability // Fields are readonly or constant
@@ -87,7 +86,7 @@ namespace Yaapii.Atoms.Enumerator
             }
         }
 
-        object IEnumerator.Current => throw new NotImplementedException();
+        object IEnumerator.Current => Current;
     }
 }
 #pragma warning restore NoProperties // No Properties

--- a/src/Yaapii.Atoms/Lists/ListOf.cs
+++ b/src/Yaapii.Atoms/Lists/ListOf.cs
@@ -35,14 +35,14 @@ namespace Yaapii.Atoms.List
         /// ctor
         /// </summary>
         /// <param name="array">source array</param>
-        public ListOf(params T[] array) : this(new ManyOf<T>(array))
+        public ListOf(params T[] array) : this(new LiveMany<T>(array))
         { }
 
         /// <summary>
         /// ctor
         /// </summary>
         /// <param name="src">source enumerator</param>
-        public ListOf(IEnumerator<T> src) : this(new ManyOf<T>(() => src))
+        public ListOf(IEnumerator<T> src) : base(() => src, false)
         { }
 
         /// <summary>
@@ -50,15 +50,7 @@ namespace Yaapii.Atoms.List
         /// </summary>
         /// <param name="src">source enumerable</param>
         public ListOf(IEnumerable<T> src) : base(
-            () =>
-            {
-                var temp = new List<T>();
-                foreach (T item in src)
-                {
-                    temp.Add(item);
-                }
-                return temp;
-            },
+            () => src.GetEnumerator(),
             false
         )
         { }

--- a/src/Yaapii.Atoms/Lists/Mapped.cs
+++ b/src/Yaapii.Atoms/Lists/Mapped.cs
@@ -78,9 +78,7 @@ namespace Yaapii.Atoms.List
         /// <param name="mapping">mapping function</param>
         /// <param name="src">source enumerator</param>
         public Mapped(Func<In, Out> mapping, ICollection<In> src) : base(() =>
-            new ListOf<Out>(
-                new Collection.Mapped<In, Out>(mapping, src)
-            ),
+            new Enumerator.Mapped<In, Out>(src.GetEnumerator(), mapping),
             false
         )
         { }

--- a/src/Yaapii.Atoms/Lists/NotEmpty.cs
+++ b/src/Yaapii.Atoms/Lists/NotEmpty.cs
@@ -48,7 +48,7 @@ namespace Yaapii.Atoms.List
         /// <param name="origin">List</param>
         /// <param name="ex">Execption to be thrown if empty</param>
         public NotEmpty(IList<T> origin, Exception ex) : base(
-            new Live<IList<T>>(
+            new Live<IEnumerable<T>>(
                 () =>
                 {
                     new FailPrecise(

--- a/src/Yaapii.Atoms/Lists/SyncList.cs
+++ b/src/Yaapii.Atoms/Lists/SyncList.cs
@@ -65,8 +65,8 @@ namespace Yaapii.Atoms.List
         /// <param name="syncRoot">root object to sync</param>
         /// <param name="col"></param>
         public SyncList(object syncRoot, IList<T> col) : base(
-            new Scalar.Sync<IList<T>>(
-                new Live<IList<T>>(() =>
+            new Scalar.Sync<IEnumerable<T>>(
+                new Live<IEnumerable<T>>(() =>
                 {
                     lock (syncRoot)
                     {

--- a/tests/Yaapii.Atoms.Tests/Collection/ArrayListAsCollectionTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Collection/ArrayListAsCollectionTest.cs
@@ -37,7 +37,9 @@ namespace Yaapii.Atoms.Enumerable.Tests
                 "A",
                 new ItemAt<object>(
                     new ArrayListAsCollection(arr)
-                ).Value().ToString()
+                )
+                .Value()
+                .ToString()
             );
         }
     }

--- a/tests/Yaapii.Atoms.Tests/Enumerable/EndlessTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Enumerable/EndlessTest.cs
@@ -38,8 +38,10 @@ namespace Yaapii.Atoms.Enumerable.Tests
             Assert.True(
                 new ItemAt<int>(
                     new Endless<int>(1),
-                    0).Value() == 1,
-                "Can't get unique endless iterable item");
+                    0
+                ).Value() == 1,
+                "Can't get unique endless iterable item"
+            );
         }
     }
 }

--- a/tests/Yaapii.Atoms.Tests/Enumerable/FilteredTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Enumerable/FilteredTest.cs
@@ -22,14 +22,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
-using Xunit;
-using Yaapii.Atoms.List;
-using Yaapii.Atoms.Func;
-using System.Linq;
-using Yaapii.Atoms.Tests;
-using Yaapii.Atoms.Enumerable;
 using System.Diagnostics;
+using System.Linq;
+using Xunit;
+using Yaapii.Atoms.Tests;
 
 namespace Yaapii.Atoms.Enumerable.Tests
 {
@@ -42,8 +38,36 @@ namespace Yaapii.Atoms.Enumerable.Tests
                 new LengthOf(
                     new Filtered<string>(
                        (input) => input != "B",
-                       new List<string>() { "A", "B", "C" })).Value() == 2,
-                "cannot filter items");
+                       new List<string>() { "A", "B", "C" }
+                    )
+                ).Value() == 2,
+                "cannot filter items"
+            );
+        }
+
+        [Fact]
+        public void CachesFilterResult()
+        {
+            var filterings = 0;
+            var filtered =
+                new Filtered<string>(
+                    (input) =>
+                    {
+                        filterings++;
+                        return input != "B";
+                    },
+                    new List<string>() { "A", "B", "C" }
+                );
+
+            var enm1 = filtered.GetEnumerator();
+            enm1.MoveNext();
+            var current = enm1.Current;
+
+            var enm2 = filtered.GetEnumerator();
+            enm2.MoveNext();
+            var current2 = enm2.Current;
+
+            Assert.Equal(1, filterings);
         }
 
         [Fact]
@@ -52,11 +76,12 @@ namespace Yaapii.Atoms.Enumerable.Tests
             Assert.True(
                 new LengthOf(
                     new Filtered<string>(
-
                         input => input.Length > 1,
-                        new ManyOf<String>())
-                    ).Value() == 0,
-                "cannot filter empty enumerable");
+                        new ManyOf<String>()
+                    )
+                ).Value() == 0,
+                "cannot filter empty enumerable"
+            );
         }
 
         [Fact]

--- a/tests/Yaapii.Atoms.Tests/Enumerator/CachedTests.cs
+++ b/tests/Yaapii.Atoms.Tests/Enumerator/CachedTests.cs
@@ -22,6 +22,7 @@
 
 using System.Collections.Generic;
 using Xunit;
+using Yaapii.Atoms.Enumerable;
 
 namespace Yaapii.Atoms.Enumerator
 {
@@ -33,8 +34,8 @@ namespace Yaapii.Atoms.Enumerator
             var advances = 0;
             var contents = new List<int>() { 1 };
             var enumerator =
-                new Cached<int>(
-                    new Cached<int>.Cache<int>(() => contents.GetEnumerator())
+                new Sticky<int>(
+                    new Sticky<int>.Cache<int>(() => contents.GetEnumerator())
                 );
 
             while (enumerator.MoveNext())
@@ -53,8 +54,8 @@ namespace Yaapii.Atoms.Enumerator
             var advances = 0;
             var contents = new List<int>() { 1, 2, 3 };
             var enumerator =
-                new Cached<int>(
-                    new Cached<int>.Cache<int>(() => contents.GetEnumerator())
+                new Sticky<int>(
+                    new Sticky<int>.Cache<int>(() => contents.GetEnumerator())
                 );
 
             while (enumerator.MoveNext())
@@ -74,10 +75,28 @@ namespace Yaapii.Atoms.Enumerator
         }
 
         [Fact]
+        public void DoesNotMoveWhenEmpty()
+        {
+            bool moved = false;
+            var contents = new List<int>();
+            var cache =
+                new Sticky<int>.Cache<int>(() =>
+                    new LoggingEnumerator<int>(
+                        contents.GetEnumerator(),
+                        idx => moved = true
+                    )
+                );
+
+            var count = cache.Count;
+
+            Assert.False(moved);
+        }
+
+        [Fact]
         public void CacheCachesItemCount()
         {
             var contents = new List<int>() { 1 };
-            var cache = new Cached<int>.Cache<int>(() => contents.GetEnumerator());
+            var cache = new Sticky<int>.Cache<int>(() => contents.GetEnumerator());
 
             var count = cache.Count;
 

--- a/tests/Yaapii.Atoms.Tests/Lists/ListOfTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Lists/ListOfTest.cs
@@ -22,6 +22,7 @@
 
 using System.Threading;
 using Xunit;
+using Yaapii.Atoms.Enumerable;
 using Yaapii.Atoms.Scalar;
 
 namespace Yaapii.Atoms.List.Tests
@@ -39,8 +40,90 @@ namespace Yaapii.Atoms.List.Tests
                         new Live<int>(() => Interlocked.Increment(ref size))
                 ));
 
-            Assert.Equal(3, new Enumerable.LengthOf(list).Value());
-            Assert.Equal(3, new Enumerable.LengthOf(list).Value());
+            Assert.Equal(
+                new Enumerable.LengthOf(list).Value(),
+                new Enumerable.LengthOf(list).Value()
+            );
+        }
+
+        [Fact]
+        public void ContainsWorksWithFirstItem()
+        {
+            var list = new ListOf<string>("item");
+            Assert.Contains("item", list);
+        }
+
+        [Fact]
+        public void ContainsWorksWithHigherItem()
+        {
+            var list = new ListOf<string>("item1", "item2", "item3");
+            Assert.Contains("item2", list);
+        }
+
+        [Fact]
+        public void CountingAdvancesAll()
+        {
+            var advances = 0;
+            var origin = new ListOf<string>("item1", "item2", "item3");
+
+            var list =
+                new ListOf<string>(
+                    new Enumerator.Sticky<string>(
+                        new Enumerator.Sticky<string>.Cache<string>(() =>
+                            new LoggingEnumerator<string>(
+                                origin.GetEnumerator(),
+                                idx => advances++
+                            )
+                        )
+                    )
+                );
+
+            var count = list.Count;
+
+            Assert.Equal(3, advances);
+
+        }
+
+        [Fact]
+        public void FindsIndexOf()
+        {
+            var lst = new ListOf<string>("item1", "item2", "item3");
+
+            Assert.Equal(
+                2,
+                lst.IndexOf("item3")
+            );
+        }
+
+        [Fact]
+        public void DeliversIndexWhenNoFinding()
+        {
+            var lst = new ListOf<string>("item1", "item2", "item3");
+
+            Assert.Equal(
+                -1,
+                lst.IndexOf("item100")
+            );
+        }
+
+        [Fact]
+        public void CanCopyTo()
+        {
+            var array = new string[5];
+            var origin = new ListOf<string>("item1", "item2", "item3");
+            origin.CopyTo(array, 2);
+
+            Assert.Equal(
+                new string[] { null, null, "item1", "item2", "item3" },
+                array
+            );
+        }
+
+        [Fact]
+        public void ContainsWorksWithEmptyList()
+        {
+            var list = new ListOf<string>();
+            Assert.DoesNotContain("item", list);
         }
     }
 }

--- a/tests/Yaapii.Atoms.Tests/Lists/LiveListTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Lists/LiveListTest.cs
@@ -43,21 +43,23 @@ namespace Yaapii.Atoms.List.Tests
         [Fact]
         public void LowBoundTest()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(
-                () => 
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
                 new LiveList<int>(() =>
-                    new List<int>() { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
-                    [-1]);
+                    new List<int>() { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }
+                )
+                [-1]
+            );
         }
 
         [Fact]
         public void HighBoundTest()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(
-                () =>
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
                 new LiveList<int>(() =>
-                    new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
-                        [11]);
+                    new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }
+                )
+                [11]
+            );
         }
 
         [Fact]

--- a/tests/Yaapii.Atoms.Tests/RandomBytes.cs
+++ b/tests/Yaapii.Atoms.Tests/RandomBytes.cs
@@ -53,7 +53,7 @@ namespace Yaapii.Atoms.Tests
         /// </summary>
         /// <param name="lst">List</param>
         /// <param name="live"></param>
-        public RandomBytes(IScalar<IList<byte>> lst, bool live) : base(lst, live)
+        public RandomBytes(IScalar<IList<byte>> lst, bool live) : base(() => lst.Value().GetEnumerator(), live)
         {
         }
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
new ListOf<int>().Contains(1) fails with an Exception.

### What is the new behavior?
The Contains method works.
Before, ListOf used a cached enumerator inside. Measurings have concluded that this is about 30-40% slower than using the native List<string>() enumerator. The reason for caching arose when regarding objects Mapped and Filtered, which apply a function to each item. Solution was refactoring so that only these objects use the Cached Enumerator.

### Does this PR introduce a breaking change? (check one with "x")
- [ ] Yes
- [x] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications

###  Other information