### PR TITLE
I505 zip files handles directories inconsistently

### DIFF
--- a/src/Yaapii.Atoms/IO/Zip.cs
+++ b/src/Yaapii.Atoms/IO/Zip.cs
@@ -19,6 +19,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+using System;
 using System.IO;
 using System.IO.Compression;
 using Yaapii.Atoms;
@@ -49,15 +50,24 @@ public sealed class Zip : IInput
     public Stream Stream()
     {
         AssumeIsDirectory(this.path);
+
+        var directories = Directory.GetFiles(this.path, "*", SearchOption.AllDirectories);
+        var array = new string[directories.Length];
+        for (int i = 0; i < directories.Length; i++)
+        {
+            array[i] = Path.GetFileName(directories[i]);
+        }
         var memory = new MemoryStream();
         using (var zip = new ZipArchive(memory, ZipArchiveMode.Create, true))
         {
-            foreach (var file in Directory.GetFiles(this.path, "*", SearchOption.AllDirectories))
+            for (int i = 0; i < directories.Length; i++)
             {
-                var entry = zip.CreateEntry(file);
+                var entry = zip.CreateEntry(array[i]);
                 new LengthOf(
                     new TeeInput(
-                        new InputOf(file),
+                        new InputOf(
+                            new Uri(directories[i])
+                        ),
                         new OutputTo(entry.Open())
                     )
                 ).Value();

--- a/tests/Yaapii.Atoms.Tests/IO/ZipTest.cs
+++ b/tests/Yaapii.Atoms.Tests/IO/ZipTest.cs
@@ -34,8 +34,8 @@ namespace Yaapii.Atoms.IO.Tests
         public void HasData()
         {
             string folder = Path.Combine(Directory.GetCurrentDirectory(), "ZipTest");
-            //try
-            //{
+            try
+            {
                 Directory.CreateDirectory(folder);
                 var newFile = File.Create(folder + "\\FileToZipOne.txt");
                 newFile.Close();
@@ -47,12 +47,12 @@ namespace Yaapii.Atoms.IO.Tests
                 var archive = new Zip(folder);
                 Assert.InRange<long>(archive.Stream().Length, 1, long.MaxValue);
 
-            //}
-            //finally
-            //{
-            //    Directory.Delete(folder, true);
-            //}
-        }
+            }
+            finally
+            {
+                Directory.Delete(folder, true);
+            }
+}
 
         [Fact]
         public void HasEntry()


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds
- [ x I merged the master into this branch before pushing
- [ x The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
#505 

### What is the new behavior?
Files from the target directory are correctly loaded into the zip archive stream

### Does this PR introduce a breaking change? (check one with "x")
- [x] Yes
- [ ] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications
the entries in the zip archive stream are made relative to the zip file path and not absolute 

###  Other information