### PR TITLE
Intruduce Map.LazySorted in and make Sorted not lazy anymore

### DIFF
--- a/src/Yaapii.Atoms/Map/KeyComparer.cs
+++ b/src/Yaapii.Atoms/Map/KeyComparer.cs
@@ -1,0 +1,50 @@
+// MIT License
+//
+// Copyright(c) 2023 ICARUS Consulting GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
+
+namespace Yaapii.Atoms.Map
+{
+    /// <summary>
+    /// Comparer comparing two KeyValuePairs by key
+    /// </summary>
+    /// <typeparam name="Key">Key Type</typeparam>
+    /// <typeparam name="Value">Value Type</typeparam>
+    internal sealed class KeyComparer<Key, Value> : IComparer<KeyValuePair<Key, Value>>
+    {
+        private readonly IComparer<Key> cmp;
+
+        /// <summary>
+        /// Comparer comparing two KeyValuePairs by key
+        /// </summary>
+        /// <param name="cmp">Comparer compairing the key type</param>
+        public KeyComparer(IComparer<Key> cmp)
+        {
+            this.cmp = cmp;
+        }
+
+        public int Compare(KeyValuePair<Key, Value> x, KeyValuePair<Key, Value> y)
+        {
+            return this.cmp.Compare(x.Key, y.Key);
+        }
+    }
+}

--- a/src/Yaapii.Atoms/Map/LazySorted.cs
+++ b/src/Yaapii.Atoms/Map/LazySorted.cs
@@ -1,0 +1,449 @@
+// MIT License
+//
+// Copyright(c) 2023 ICARUS Consulting GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using Yaapii.Atoms.Enumerable;
+
+namespace Yaapii.Atoms.Map
+{
+    /// <summary>
+    /// Sorts the given map with the given comparer
+    /// </summary>
+    /// <typeparam name="Key">Key Type of the Map</typeparam>
+    /// <typeparam name="Value">Value Type of the Map</typeparam>
+    public sealed class LazySorted<Key, Value> : MapEnvelope<Key, Value>
+    {
+        /// <summary>
+        /// Sorts the given map with the default comperator of the key
+        /// </summary>
+        /// <param name="dict">Map to be sorted</param>
+        public LazySorted(IDictionary<Key, Value> dict)
+            : this(dict, Comparer<Key>.Default)
+        { }
+
+        /// <summary>
+        /// Sorts the given map with the given compare function
+        /// </summary>
+        /// <param name="dict">Map to be sorted</param>
+        /// <param name="compare">Function to compare two keys</param>
+        public LazySorted(IDictionary<Key, Value> dict, Func<Key, Key, int> compare)
+            : this(dict, new SimpleComparer<Key>(compare))
+        { }
+
+        /// <summary>
+        /// Sorts the given map with the default comperator of the key
+        /// </summary>
+        /// <param name="pairs">Map elements to be sorted</param>
+        public LazySorted(IEnumerable<KeyValuePair<Key, Value>> pairs)
+            : this(pairs, Comparer<Key>.Default)
+        { }
+
+        /// <summary>
+        /// Sorts the given map with the given key compare function
+        /// </summary>
+        /// <param name="pairs">Map elements to be sorted</param>
+        /// <param name="compare">Function to compare two keys</param>
+        public LazySorted(IEnumerable<KeyValuePair<Key, Value>> pairs, Func<Key, Key, int> compare)
+            : this(pairs, new SimpleComparer<Key>(compare))
+        { }
+
+        /// <summary>
+        /// Sorts the given map with the given compare function
+        /// </summary>
+        /// <param name="pairs">Map elements to be sorted</param>
+        /// <param name="compare">Function to compare two elements</param>
+        public LazySorted(IEnumerable<KeyValuePair<Key, Value>> pairs, Func<KeyValuePair<Key, Value>, KeyValuePair<Key, Value>, int> compare)
+            : this(pairs, new SimpleComparer<KeyValuePair<Key, Value>>(compare))
+        { }
+
+        /// <summary>
+        /// Sorts the given map with the given key comparer
+        /// </summary>
+        /// <param name="pairs">Map elements to be sorted</param>
+        /// <param name="cmp">Comparer comparing keys</param>
+        public LazySorted(IEnumerable<KeyValuePair<Key, Value>> pairs, IComparer<Key> cmp)
+            : this(pairs, new KeyComparer<Key, Value>(cmp))
+        { }
+
+        /// <summary>
+        /// Sorts the given map with the given comparer
+        /// </summary>
+        /// <param name="pairs">Map elements to be sorted</param>
+        /// <param name="cmp">Comparer comparing elements</param>
+        public LazySorted(IEnumerable<KeyValuePair<Key, Value>> pairs, IComparer<KeyValuePair<Key, Value>> cmp)
+            : base(
+                () =>
+                {
+                    var items = new List<KeyValuePair<Key, Value>>(pairs);
+                    items.Sort(cmp);
+                    return new MapOf<Key, Value>(items);
+                },
+                false
+            )
+        { }
+
+        /// <summary>
+        /// Sorts the given map with the given comparer
+        /// </summary>
+        /// <param name="dict">Map to be sorted</param>
+        /// <param name="cmp">Comparer comparing keys</param>
+        public LazySorted(IDictionary<Key, Value> dict, IComparer<Key> cmp)
+            : base(
+                () =>
+                {
+                    var keys = new List<Key>(dict.Keys);
+                    keys.Sort(cmp);
+                    var result = new LazyDict<Key, Value>(
+                        new Mapped<Key, IKvp<Key, Value>>(
+                            key => new KvpOf<Key, Value>(key, () => dict[key]),
+                            keys
+                        )
+                    );
+                    return result;
+                },
+                false
+            )
+        { }
+    }
+
+    /// <summary>
+    /// Sorts the given map with the given comparer
+    /// </summary>
+    /// <typeparam name="Value">Value Type of the Map</typeparam>
+    public sealed class LazySorted<Value> : MapEnvelope<Value>
+    {
+        /// <summary>
+        /// Sorts the given map with the default comperator of the key
+        /// </summary>
+        /// <param name="dict">Map to be sorted</param>
+        public LazySorted(IDictionary<string, Value> dict)
+            : this(dict, Comparer<string>.Default)
+        { }
+
+        /// <summary>
+        /// Sorts the given map with the given compare function
+        /// </summary>
+        /// <param name="dict">Map to be sorted</param>
+        /// <param name="compare">Function to compare two keys</param>
+        public LazySorted(IDictionary<string, Value> dict, Func<string, string, int> compare)
+            : this(dict, new SimpleComparer<string>(compare))
+        { }
+
+        /// <summary>
+        /// Sorts the given map with the default comperator of the key
+        /// </summary>
+        /// <param name="pairs">Map elements to be sorted</param>
+        public LazySorted(IEnumerable<KeyValuePair<string, Value>> pairs)
+            : this(pairs, Comparer<string>.Default)
+        { }
+
+        /// <summary>
+        /// Sorts the given map with the given key compare function
+        /// </summary>
+        /// <param name="pairs">Map elements to be sorted</param>
+        /// <param name="compare">Function to compare two keys</param>
+        public LazySorted(IEnumerable<KeyValuePair<string, Value>> pairs, Func<string, string, int> compare)
+            : this(pairs, new SimpleComparer<string>(compare))
+        { }
+
+        /// <summary>
+        /// Sorts the given map with the given compare function
+        /// </summary>
+        /// <param name="pairs">Map elements to be sorted</param>
+        /// <param name="compare">Function to compare two elements</param>
+        public LazySorted(IEnumerable<KeyValuePair<string, Value>> pairs, Func<KeyValuePair<string, Value>, KeyValuePair<string, Value>, int> compare)
+            : this(pairs, new SimpleComparer<KeyValuePair<string, Value>>(compare))
+        { }
+
+        /// <summary>
+        /// Sorts the given map with the given key comparer
+        /// </summary>
+        /// <param name="pairs">Map elements to be sorted</param>
+        /// <param name="cmp">Comparer comparing keys</param>
+        public LazySorted(IEnumerable<KeyValuePair<string, Value>> pairs, IComparer<string> cmp)
+            : this(pairs, new KeyComparer<string, Value>(cmp))
+        { }
+
+        /// <summary>
+        /// Sorts the given map with the given comparer
+        /// </summary>
+        /// <param name="pairs">Map elements to be sorted</param>
+        /// <param name="cmp">Comparer comparing elements</param>
+        public LazySorted(IEnumerable<KeyValuePair<string, Value>> pairs, IComparer<KeyValuePair<string, Value>> cmp)
+            : base(
+                () =>
+                {
+                    var items = new List<KeyValuePair<string, Value>>(pairs);
+                    items.Sort(cmp);
+                    return new MapOf<string, Value>(items);
+                },
+                false
+            )
+        { }
+
+        /// <summary>
+        /// Sorts the given map with the given comparer
+        /// </summary>
+        /// <param name="dict">Map to be sorted</param>
+        /// <param name="cmp">Comparer comparing keys</param>
+        public LazySorted(IDictionary<string, Value> dict, IComparer<string> cmp)
+            : base(
+                () =>
+                {
+                    var keys = new List<string>(dict.Keys);
+                    keys.Sort(cmp);
+                    var result = new LazyDict<string, Value>(
+                        new Mapped<string, IKvp<string, Value>>(
+                            key => new KvpOf<string, Value>(key, () => dict[key]),
+                            keys
+                        )
+                    );
+                    return result;
+                },
+                false
+            )
+        { }
+    }
+
+    /// <summary>
+    /// Sorts the given map with the given comparer
+    /// </summary>
+    public sealed class LazySorted : MapEnvelope
+    {
+        /// <summary>
+        /// Sorts the given map with the default comperator of the key
+        /// </summary>
+        /// <param name="dict">Map to be sorted</param>
+        public LazySorted(IDictionary<string, string> dict)
+            : this(dict, Comparer<string>.Default)
+        { }
+
+        /// <summary>
+        /// Sorts the given map with the given compare function
+        /// </summary>
+        /// <param name="dict">Map to be sorted</param>
+        /// <param name="compare">Function to compare two keys</param>
+        public LazySorted(IDictionary<string, string> dict, Func<string, string, int> compare)
+            : this(dict, new SimpleComparer<string>(compare))
+        { }
+
+        /// <summary>
+        /// Sorts the given map with the default comperator of the key
+        /// </summary>
+        /// <param name="pairs">Map elements to be sorted</param>
+        public LazySorted(IEnumerable<KeyValuePair<string, string>> pairs)
+            : this(pairs, Comparer<string>.Default)
+        { }
+
+        /// <summary>
+        /// Sorts the given map with the given key compare function
+        /// </summary>
+        /// <param name="pairs">Map elements to be sorted</param>
+        /// <param name="compare">Function to compare two keys</param>
+        public LazySorted(IEnumerable<KeyValuePair<string, string>> pairs, Func<string, string, int> compare)
+            : this(pairs, new SimpleComparer<string>(compare))
+        { }
+
+        /// <summary>
+        /// Sorts the given map with the given compare function
+        /// </summary>
+        /// <param name="pairs">Map elements to be sorted</param>
+        /// <param name="compare">Function to compare two elements</param>
+        public LazySorted(IEnumerable<KeyValuePair<string, string>> pairs, Func<KeyValuePair<string, string>, KeyValuePair<string, string>, int> compare)
+            : this(pairs, new SimpleComparer<KeyValuePair<string, string>>(compare))
+        { }
+
+        /// <summary>
+        /// Sorts the given map with the given key comparer
+        /// </summary>
+        /// <param name="pairs">Map elements to be sorted</param>
+        /// <param name="cmp">Comparer comparing keys</param>
+        public LazySorted(IEnumerable<KeyValuePair<string, string>> pairs, IComparer<string> cmp)
+            : this(pairs, new KeyComparer<string, string>(cmp))
+        { }
+
+        /// <summary>
+        /// Sorts the given map with the given comparer
+        /// </summary>
+        /// <param name="pairs">Map elements to be sorted</param>
+        /// <param name="cmp">Comparer comparing elements</param>
+        public LazySorted(IEnumerable<KeyValuePair<string, string>> pairs, IComparer<KeyValuePair<string, string>> cmp)
+            : base(
+                () =>
+                {
+                    var items = new List<KeyValuePair<string, string>>(pairs);
+                    items.Sort(cmp);
+                    return new MapOf<string, string>(items);
+                },
+                false
+            )
+        { }
+
+        /// <summary>
+        /// Sorts the given map with the given comparer
+        /// </summary>
+        /// <param name="dict">Map to be sorted</param>
+        /// <param name="cmp">Comparer comparing keys</param>
+        public LazySorted(IDictionary<string, string> dict, IComparer<string> cmp)
+            : base(
+                () =>
+                {
+                    var keys = new List<string>(dict.Keys);
+                    keys.Sort(cmp);
+                    var result = new LazyDict<string, string>(
+                        new Mapped<string, IKvp<string, string>>(
+                            key => new KvpOf<string, string>(key, () => dict[key]),
+                            keys
+                        )
+                    );
+                    return result;
+                },
+                false
+            )
+        { }
+
+        /// <summary>
+        /// Sorts the given map with the default comperator of the key
+        /// </summary>
+        /// <param name="dict">Map to be sorted</param>
+        public static IDictionary<Key, Value> New<Key, Value>(IDictionary<Key, Value> dict)
+            => new LazySorted<Key, Value>(dict);
+
+        /// <summary>
+        /// Sorts the given map with the given compare function
+        /// </summary>
+        /// <param name="dict">Map to be sorted</param>
+        /// <param name="compare">Function to compare two keys</param>
+        public static IDictionary<Key, Value> New<Key, Value>(IDictionary<Key, Value> dict, Func<Key, Key, int> compare)
+            => new LazySorted<Key, Value>(dict, compare);
+
+        /// <summary>
+        /// Sorts the given map with the default comperator of the key
+        /// </summary>
+        /// <param name="pairs">Map elements to be sorted</param>
+        public static IDictionary<Key, Value> New<Key, Value>(IEnumerable<KeyValuePair<Key, Value>> pairs)
+            => new LazySorted<Key, Value>(pairs);
+
+        /// <summary>
+        /// Sorts the given map with the given key compare function
+        /// </summary>
+        /// <param name="pairs">Map elements to be sorted</param>
+        /// <param name="compare">Function to compare two keys</param>
+        public static IDictionary<Key, Value> New<Key, Value>(IEnumerable<KeyValuePair<Key, Value>> pairs, Func<Key, Key, int> compare)
+            => new LazySorted<Key, Value>(pairs, compare);
+
+        /// <summary>
+        /// Sorts the given map with the given compare function
+        /// </summary>
+        /// <param name="pairs">Map elements to be sorted</param>
+        /// <param name="compare">Function to compare two elements</param>
+        public static IDictionary<Key, Value> New<Key, Value>(IEnumerable<KeyValuePair<Key, Value>> pairs, Func<KeyValuePair<Key, Value>, KeyValuePair<Key, Value>, int> compare)
+            => new LazySorted<Key, Value>(pairs, compare);
+
+        /// <summary>
+        /// Sorts the given map with the given key comparer
+        /// </summary>
+        /// <param name="pairs">Map elements to be sorted</param>
+        /// <param name="cmp">Comparer comparing keys</param>
+        public static IDictionary<Key, Value> New<Key, Value>(IEnumerable<KeyValuePair<Key, Value>> pairs, IComparer<Key> cmp)
+            => new LazySorted<Key, Value>(pairs, cmp);
+
+        /// <summary>
+        /// Sorts the given map with the given comparer
+        /// </summary>
+        /// <param name="pairs">Map elements to be sorted</param>
+        /// <param name="cmp">Comparer comparing elements</param>
+        public static IDictionary<Key, Value> New<Key, Value>(IEnumerable<KeyValuePair<Key, Value>> pairs, IComparer<KeyValuePair<Key, Value>> cmp)
+            => new LazySorted<Key, Value>(pairs, cmp);
+
+        /// <summary>
+        /// Sorts the given map with the given comparer
+        /// </summary>
+        /// <param name="dict">Map to be sorted</param>
+        /// <param name="cmp">Comparer comparing keys</param>
+        public static IDictionary<Key, Value> New<Key, Value>(IDictionary<Key, Value> dict, IComparer<Key> cmp)
+            => new LazySorted<Key, Value>(dict, cmp);
+
+        /// <summary>
+        /// Sorts the given map with the default comperator of the key
+        /// </summary>
+        /// <param name="dict">Map to be sorted</param>
+        public static IDictionary<string, Value> New<Value>(IDictionary<string, Value> dict)
+            => new LazySorted<Value>(dict);
+
+        /// <summary>
+        /// Sorts the given map with the given compare function
+        /// </summary>
+        /// <param name="dict">Map to be sorted</param>
+        /// <param name="compare">Function to compare two keys</param>
+        public static IDictionary<string, Value> New<Value>(IDictionary<string, Value> dict, Func<string, string, int> compare)
+            => new LazySorted<Value>(dict, compare);
+
+        /// <summary>
+        /// Sorts the given map with the default comperator of the key
+        /// </summary>
+        /// <param name="pairs">Map elements to be sorted</param>
+        public static IDictionary<string, Value> New<Value>(IEnumerable<KeyValuePair<string, Value>> pairs)
+            => new LazySorted<Value>(pairs);
+
+        /// <summary>
+        /// Sorts the given map with the given key compare function
+        /// </summary>
+        /// <param name="pairs">Map elements to be sorted</param>
+        /// <param name="compare">Function to compare two keys</param>
+        public static IDictionary<string, Value> New<Value>(IEnumerable<KeyValuePair<string, Value>> pairs, Func<string, string, int> compare)
+            => new LazySorted<Value>(pairs, compare);
+
+        /// <summary>
+        /// Sorts the given map with the given compare function
+        /// </summary>
+        /// <param name="pairs">Map elements to be sorted</param>
+        /// <param name="compare">Function to compare two elements</param>
+        public static IDictionary<string, Value> New<Value>(IEnumerable<KeyValuePair<string, Value>> pairs, Func<KeyValuePair<string, Value>, KeyValuePair<string, Value>, int> compare)
+            => new LazySorted<Value>(pairs, compare);
+
+        /// <summary>
+        /// Sorts the given map with the given key comparer
+        /// </summary>
+        /// <param name="pairs">Map elements to be sorted</param>
+        /// <param name="cmp">Comparer comparing keys</param>
+        public static IDictionary<string, Value> New<Value>(IEnumerable<KeyValuePair<string, Value>> pairs, IComparer<string> cmp)
+            => new LazySorted<Value>(pairs, cmp);
+
+        /// <summary>
+        /// Sorts the given map with the given comparer
+        /// </summary>
+        /// <param name="pairs">Map elements to be sorted</param>
+        /// <param name="cmp">Comparer comparing elements</param>
+        public static IDictionary<string, Value> New<Value>(IEnumerable<KeyValuePair<string, Value>> pairs, IComparer<KeyValuePair<string, Value>> cmp)
+            => new LazySorted<Value>(pairs, cmp);
+
+        /// <summary>
+        /// Sorts the given map with the given comparer
+        /// </summary>
+        /// <param name="dict">Map to be sorted</param>
+        /// <param name="cmp">Comparer comparing keys</param>
+        public static IDictionary<string, Value> New<Value>(IDictionary<string, Value> dict, IComparer<string> cmp)
+            => new LazySorted<Value>(dict, cmp);
+    }
+}

--- a/src/Yaapii.Atoms/Map/SimpleComparer.cs
+++ b/src/Yaapii.Atoms/Map/SimpleComparer.cs
@@ -1,0 +1,50 @@
+// MIT License
+//
+// Copyright(c) 2023 ICARUS Consulting GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+
+namespace Yaapii.Atoms.Map
+{
+    /// <summary>
+    /// Simple Comparer comparing two elements
+    /// </summary>
+    /// <typeparam name="T">Type of the elements</typeparam>
+    internal sealed class SimpleComparer<T> : IComparer<T>
+    {
+        private readonly Func<T, T, int> compare;
+
+        /// <summary>
+        /// Comparer from a function comparing two elements
+        /// </summary>
+        /// <param name="compare">Function comparing two elements</param>
+        public SimpleComparer(Func<T, T, int> compare)
+        {
+            this.compare = compare;
+        }
+
+        public int Compare(T x, T y)
+        {
+            return this.compare(x, y);
+        }
+    }
+}

--- a/src/Yaapii.Atoms/Map/Sorted.cs
+++ b/src/Yaapii.Atoms/Map/Sorted.cs
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright(c) 2022 ICARUS Consulting GmbH
+// Copyright(c) 2023 ICARUS Consulting GmbH
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -113,9 +113,9 @@ namespace Yaapii.Atoms.Map
                 {
                     var keys = new List<Key>(dict.Keys);
                     keys.Sort(cmp);
-                    var result = new LazyDict<Key, Value>(
+                    var result = new MapOf<Key, Value>(
                         new Mapped<Key, IKvp<Key, Value>>(
-                            key => new KvpOf<Key, Value>(key, () => dict[key]),
+                            key => new KvpOf<Key, Value>(key, dict[key]),
                             keys
                         )
                     );
@@ -212,9 +212,9 @@ namespace Yaapii.Atoms.Map
                 {
                     var keys = new List<string>(dict.Keys);
                     keys.Sort(cmp);
-                    var result = new LazyDict<string, Value>(
+                    var result = new MapOf<string, Value>(
                         new Mapped<string, IKvp<string, Value>>(
-                            key => new KvpOf<string, Value>(key, () => dict[key]),
+                            key => new KvpOf<string, Value>(key, dict[key]),
                             keys
                         )
                     );
@@ -310,9 +310,9 @@ namespace Yaapii.Atoms.Map
                 {
                     var keys = new List<string>(dict.Keys);
                     keys.Sort(cmp);
-                    var result = new LazyDict<string, string>(
+                    var result = new MapOf<string, string>(
                         new Mapped<string, IKvp<string, string>>(
-                            key => new KvpOf<string, string>(key, () => dict[key]),
+                            key => new KvpOf<string, string>(key, dict[key]),
                             keys
                         )
                     );
@@ -445,52 +445,5 @@ namespace Yaapii.Atoms.Map
         /// <param name="cmp">Comparer comparing keys</param>
         public static IDictionary<string, Value> New<Value>(IDictionary<string, Value> dict, IComparer<string> cmp)
             => new Sorted<Value>(dict, cmp);
-    }
-
-    /// <summary>
-    /// Simple Comparer comparing two elements
-    /// </summary>
-    /// <typeparam name="T">Type of the elements</typeparam>
-    internal sealed class SimpleComparer<T> : IComparer<T>
-    {
-        private readonly Func<T, T, int> compare;
-
-        /// <summary>
-        /// Comparer from a function comparing two elements
-        /// </summary>
-        /// <param name="compare">Function comparing two elements</param>
-        public SimpleComparer(Func<T, T, int> compare)
-        {
-            this.compare = compare;
-        }
-
-        public int Compare(T x, T y)
-        {
-            return this.compare(x, y);
-        }
-    }
-
-    /// <summary>
-    /// Comparer comparing two KeyValuePairs by key
-    /// </summary>
-    /// <typeparam name="Key">Key Type</typeparam>
-    /// <typeparam name="Value">Value Type</typeparam>
-    internal sealed class KeyComparer<Key, Value> : IComparer<KeyValuePair<Key, Value>>
-    {
-        private readonly IComparer<Key> cmp;
-
-        /// <summary>
-        /// Comparer comparing two KeyValuePairs by key
-        /// </summary>
-        /// <param name="cmp">Comparer compairing the key type</param>
-        public KeyComparer(IComparer<Key> cmp)
-        {
-            this.cmp = cmp;
-        }
-
-        public int Compare(KeyValuePair<Key, Value> x, KeyValuePair<Key, Value> y)
-        {
-            return this.cmp.Compare(x.Key, y.Key);
-        }
     }
 }

--- a/tests/Yaapii.Atoms.Tests/Map/LazySortedTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Map/LazySortedTest.cs
@@ -1,0 +1,181 @@
+// MIT License
+//
+// Copyright(c) 2023 ICARUS Consulting GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Yaapii.Atoms.Map.Tests
+{
+    public sealed class LazySortedTest
+    {
+        [Theory]
+        [InlineData(1, 4)]
+        [InlineData(6, 3)]
+        [InlineData(-5, 2)]
+        public void ValueStillBehindCorrectKeyDict(int key, int expectedValue)
+        {
+            var unsorted = new Dictionary<int, int>()
+            {
+                {1, 4 },
+                {6, 3 },
+                {-5, 2}
+            };
+            Assert.Equal(expectedValue, unsorted[key]);
+            var sorted = new LazySorted<int, int>(unsorted);
+            Assert.Equal(expectedValue, sorted[key]);
+        }
+
+        [Theory]
+        [InlineData(1, 4)]
+        [InlineData(6, 3)]
+        [InlineData(-5, 2)]
+        public void ValueStillBehindCorrectKeyIEnumerableKeyValuePairs(int key, int expectedValue)
+        {
+            var unsorted = new List<KeyValuePair<int, int>>()
+            {
+                new KeyValuePair<int, int>(1, 4),
+                new KeyValuePair<int, int>(6, 3),
+                new KeyValuePair<int, int>(-5, 2)
+            };
+            var sorted = new LazySorted<int, int>(unsorted);
+            Assert.Equal(expectedValue, sorted[key]);
+        }
+
+        [Theory]
+        [InlineData(0, -5)]
+        [InlineData(1, 6)]
+        [InlineData(2, 1)]
+        public void SortsByFunction(int index, int expectedKey)
+        {
+            var unsorted = new Dictionary<int, int>()
+            {
+                {1, 4 },
+                {6, 3 },
+                {-5, 2}
+            };
+            var sorted = new LazySorted<int, int>(unsorted, (a, b) => a.Value - b.Value);
+            var sortedArr = new KeyValuePair<int, int>[3];
+            sorted.CopyTo(sortedArr, 0);
+            Assert.Equal(expectedKey, sortedArr[index].Key);
+        }
+
+        [Theory]
+        [InlineData(0, -5)]
+        [InlineData(1, 1)]
+        [InlineData(2, 6)]
+        public void DefaultComparerSeemsSane(int index, int expectedKey)
+        {
+            var unsorted = new Dictionary<int, int>()
+            {
+                {1, 4 },
+                {6, 3 },
+                {-5, 2}
+            };
+            var sorted = new LazySorted<int, int>(unsorted);
+            var keys = new int[3];
+            sorted.Keys.CopyTo(keys, 0);
+            Assert.Equal(expectedKey, keys[index]);
+        }
+
+        [Theory]
+        [InlineData(0, -5)]
+        [InlineData(1, 1)]
+        [InlineData(2, 6)]
+        public void EnumeratesKeysWhenLazy(int index, int expectedKey)
+        {
+            var unsorted = new LazyDict<int, int>(false,
+                new KvpOf<int, int>(1, () => { throw new Exception("i shall not be called"); }),
+                new KvpOf<int, int>(6, () => { throw new Exception("i shall not be called"); }),
+                new KvpOf<int, int>(-5, () => { throw new Exception("i shall not be called"); })
+            );
+            var sorted = new LazySorted<int, int>(unsorted);
+            var keys = new int[3];
+            sorted.Keys.CopyTo(keys, 0);
+            Assert.Equal(expectedKey, keys[index]);
+        }
+
+        [Fact]
+        public void DeliversSingleValueWhenLazy()
+        {
+            var unsorted = new LazyDict<int, int>(false,
+                new KvpOf<int, int>(1, () => 4),
+                new KvpOf<int, int>(6, () => { throw new Exception("i shall not be called"); }),
+                new KvpOf<int, int>(-5, () => { throw new Exception("i shall not be called"); })
+            );
+            var sorted = new LazySorted<int, int>(unsorted);
+            Assert.Equal(4, sorted[1]);
+        }
+
+        [Fact]
+        public void RejectsBuildingAllValuesByDefault()
+        {
+            var unsorted = new LazyDict<int, int>(false,
+                new KvpOf<int, int>(1, () => 4),
+                new KvpOf<int, int>(6, () => { throw new Exception("i shall not be called"); }),
+                new KvpOf<int, int>(-5, () => { throw new Exception("i shall not be called"); })
+            );
+            var sorted = new LazySorted<int, int>(unsorted);
+            var ex = Assert.Throws<InvalidOperationException>(() => sorted.Values.GetEnumerator());
+            Assert.Equal("Cannot get all values because this is a lazy dictionary. Getting the values would build all keys. If you need this behaviour, set the ctor param 'rejectBuildingAllValues' to false.", ex.Message);
+        }
+
+        [Fact]
+        public void RejectsListsValuesFromGeneircKeyAndValue()
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+                new LazySorted<string, int>(
+                    MapOf.New(
+                        "a", 1,
+                        "b", 2
+                    )
+                ).Values
+            );
+        }
+
+        [Fact]
+        public void RejectsListsValuesFromGeneircValue()
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+                new LazySorted<int>(
+                    MapOf.New(
+                        "a", 1,
+                        "b", 2
+                    )
+                ).Values
+            );
+        }
+
+        [Fact]
+        public void RejectsListsValuesFromStringPairs()
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+                LazySorted.New(
+                    MapOf.New(
+                        "a", "val",
+                        "b", "val"
+                    )
+                ).Values
+            );
+        }
+    }
+}

--- a/tests/Yaapii.Atoms.Tests/Map/SortedTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Map/SortedTest.cs
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright(c) 2022 ICARUS Consulting GmbH
+// Copyright(c) 2023 ICARUS Consulting GmbH
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +23,10 @@
 using System;
 using System.Collections.Generic;
 using Xunit;
+using Yaapii.Atoms.Enumerable;
 
 namespace Yaapii.Atoms.Map.Tests
+
 {
     public sealed class SortedTest
     {
@@ -97,46 +99,71 @@ namespace Yaapii.Atoms.Map.Tests
             Assert.Equal(expectedKey, keys[index]);
         }
 
-        [Theory]
-        [InlineData(0, -5)]
-        [InlineData(1, 1)]
-        [InlineData(2, 6)]
-        public void EnumeratesKeysWhenLazy(int index, int expectedKey)
+        [Fact]
+        public void ListsValuesFromGenericKeyAndValue()
         {
-            var unsorted = new LazyDict<int, int>(false,
-                new KvpOf<int, int>(1, () => { throw new Exception("i shall not be called"); }),
-                new KvpOf<int, int>(6, () => { throw new Exception("i shall not be called"); }),
-                new KvpOf<int, int>(-5, () => { throw new Exception("i shall not be called"); })
+            Assert.Equal(
+                ManyOf.New(2, 1),
+                new Sorted<string, int>(
+                    MapOf.New(
+                        "b", 1,
+                        "a", 2
+                     ),
+                    StringComparer.CurrentCultureIgnoreCase
+                ).Values
             );
-            var sorted = new Sorted<int, int>(unsorted);
-            var keys = new int[3];
-            sorted.Keys.CopyTo(keys, 0);
-            Assert.Equal(expectedKey, keys[index]);
+
+            Assert.Equal(
+                ManyOf.New(2, 1),
+                new Sorted<int>(
+                    MapOf.New(
+                        "b", 1,
+                        "a", 2
+                     ),
+                    StringComparer.CurrentCultureIgnoreCase
+                ).Values
+            );
+
+            Assert.Equal(
+                ManyOf.New("2", "1"),
+                new Sorted(
+                    MapOf.New(
+                        "b", "1",
+                        "a", "2"
+                     ),
+                    StringComparer.CurrentCultureIgnoreCase
+                ).Values
+            );
         }
 
         [Fact]
-        public void DeliversSingleValueWhenLazy()
+        public void ListsValuesFromGenericValue()
         {
-            var unsorted = new LazyDict<int, int>(false,
-                new KvpOf<int, int>(1, () => 4),
-                new KvpOf<int, int>(6, () => { throw new Exception("i shall not be called"); }),
-                new KvpOf<int, int>(-5, () => { throw new Exception("i shall not be called"); })
+            Assert.Equal(
+                ManyOf.New(2, 1),
+                new Sorted<int>(
+                    MapOf.New(
+                        "b", 1,
+                        "a", 2
+                     ),
+                    StringComparer.CurrentCultureIgnoreCase
+                ).Values
             );
-            var sorted = new Sorted<int, int>(unsorted);
-            Assert.Equal(4, sorted[1]);
         }
 
         [Fact]
-        public void RejectsBuildingAllValuesByDefault()
+        public void ListsValuesFromStringPairs()
         {
-            var unsorted = new LazyDict<int, int>(false,
-                new KvpOf<int, int>(1, () => 4),
-                new KvpOf<int, int>(6, () => { throw new Exception("i shall not be called"); }),
-                new KvpOf<int, int>(-5, () => { throw new Exception("i shall not be called"); })
+            Assert.Equal(
+                ManyOf.New("2", "1"),
+                new Sorted(
+                    MapOf.New(
+                        "b", "1",
+                        "a", "2"
+                     ),
+                    StringComparer.CurrentCultureIgnoreCase
+                ).Values
             );
-            var sorted = new Sorted<int, int>(unsorted);
-            var ex = Assert.Throws<InvalidOperationException>(() => sorted.Values.GetEnumerator());
-            Assert.Equal("Cannot get all values because this is a lazy dictionary. Getting the values would build all keys. If you need this behaviour, set the ctor param 'rejectBuildingAllValues' to false.", ex.Message);
         }
     }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
<!-- Describe the current behavior or link to a open issue -->
fixes #530 

### What is the new behavior?
<!-- Describe the new behavior -->
Introduce `Yaapii.Map.LazySorted`
Remove lazy behavior from `Yaapi.Map.Sorted`

### Does this PR introduce a breaking change? (check one with "x")
- [x] Yes
- [ ] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications
`Sorted` is not lazy anymore. Replace it by `Yaapii.Map.LazySorted`

###  Other information