### PR TITLE
I543 joined with first second and enum crashes out of index

### DIFF
--- a/src/Yaapii.Atoms/Enumerable/Joined.cs
+++ b/src/Yaapii.Atoms/Enumerable/Joined.cs
@@ -42,7 +42,7 @@ namespace Yaapii.Atoms.Enumerable
         public Joined(T first, T second, IEnumerable<T> lst, params T[] items) : base(() =>
         {
             int idx = 2;
-            T[] joined = new T[1 + new LengthOf(lst).Value() + items.Length];
+            T[] joined = new T[2 + new LengthOf(lst).Value() + items.Length];
             joined[0] = first;
             joined[1] = second;
             var enm = lst.GetEnumerator();

--- a/tests/Yaapii.Atoms.Tests/Enumerable/JoinedTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Enumerable/JoinedTest.cs
@@ -28,7 +28,7 @@ namespace Yaapii.Atoms.Enumerable.Tests
     public sealed class JoinedTest
     {
         [Fact]
-        public void JoinsFirstSecondAndEnum()
+        public void JoinsFirstSecondAndEnumerable()
         {
             Assert.True(
                 new LengthOf(

--- a/tests/Yaapii.Atoms.Tests/Enumerable/JoinedTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Enumerable/JoinedTest.cs
@@ -28,6 +28,20 @@ namespace Yaapii.Atoms.Enumerable.Tests
     public sealed class JoinedTest
     {
         [Fact]
+        public void JoinsFirstSecondAndEnum()
+        {
+            Assert.True(
+                new LengthOf(
+                    new Joined<string>(
+                        "first",
+                        "second",
+                        new ManyOf<string>("third", "fourth")                       
+                    )
+                ).Value() == 4,
+            "cannot join first second and enum together");
+        }
+
+        [Fact]
         public void TransformsList()
         {
             Assert.True(


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
<!-- Describe the current behavior or link to a open issue -->
#543  Joined crashes with index out of bounds
### What is the new behavior?
<!-- Describe the new behavior -->
close #543  -> correct array size
### Does this PR introduce a breaking change? (check one with "x")
- [ ] Yes
- [x] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications

###  Other information