### PR TITLE
fix: outdated .net framework prevents test execution on apple silicon

### DIFF
--- a/tests/Yaapii.Atoms.Tests/Yaapii.Atoms.Tests.csproj
+++ b/tests/Yaapii.Atoms.Tests/Yaapii.Atoms.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp2.1</TargetFramework>    
+    <TargetFramework>net7.0</TargetFramework>    
     <Version>0.5.0</Version>    
     <Description>Unittests for Yaapii.Atoms</Description>    
     <PackageTags></PackageTags>
@@ -38,6 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.console" Version="2.3.1" />
     <PackageReference Include="xunit.extensibility.core" Version="2.3.1" />


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
Cannot test on apple silicon machine

### What is the new behavior?
closes #546 

### Does this PR introduce a breaking change? (check one with "x")
- [ ] Yes
- [x] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications

###  Other information
Updated to .Net7.0 which needs to be present on contributors machines.