### PR TITLE
Use CultureInfo.InvariantCulture in DateAsText

### DIFF
--- a/src/Yaapii.Atoms/Time/DateAsText.cs
+++ b/src/Yaapii.Atoms/Time/DateAsText.cs
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright(c) 2023 ICARUS Consulting GmbH
+// Copyright(c) 2024 ICARUS Consulting GmbH
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -43,47 +43,64 @@ namespace Yaapii.Atoms.Time
         /// <summary>
         /// A date formatted as ISO
         /// </summary>
-        /// <param name="date"></param>
+        /// <param name="date">a date</param>
         public DateAsText(DateTime date) : this(new Live<DateTime>(date), "o")
         { }
 
         /// <summary>
         /// A date formatted as ISO
         /// </summary>
-        /// <param name="date"></param>
+        /// <param name="date">a date</param>
+        /// <param name="provider">a format provider</param>
+        public DateAsText(DateTime date, IFormatProvider provider) : this(date, "o", provider)
+        { }
+
+        /// <summary>
+        /// A date formatted as ISO
+        /// </summary>
+        /// <param name="date">a date</param>
         public DateAsText(IScalar<DateTime> date) : this(date, "o")
         { }
 
         /// <summary>
-        /// A date formatted by using a format-string and <see cref="CultureInfo.CurrentCulture"/>
+        /// A date formatted by using a format-string and <see cref="CultureInfo.InvariantCulture"/>
         /// </summary>
         /// <param name="date">a date</param>
         /// <param name="format">a format pattern</param>
-        public DateAsText(DateTime date, string format) : this(new Live<DateTime>(date), new TextOf(format), CultureInfo.CurrentCulture)
+        public DateAsText(DateTime date, string format) : this(new Live<DateTime>(date), new TextOf(format), CultureInfo.InvariantCulture)
         { }
 
         /// <summary>
-        /// A date formatted by using a format-string and <see cref="CultureInfo.CurrentCulture"/>
+        /// A date formatted by using a format-string and <see cref="CultureInfo.InvariantCulture"/>
         /// </summary>
         /// <param name="date">a date</param>
         /// <param name="format">a format pattern</param>
-        public DateAsText(IScalar<DateTime> date, string format) : this(date, new LiveText(format), CultureInfo.CurrentCulture)
+        /// <param name="provider">a format provider</param>
+        public DateAsText(DateTime date, string format, IFormatProvider provider) : this(new Live<DateTime>(date), new TextOf(format), provider)
         { }
 
         /// <summary>
-        /// A date formatted by using a format-string and <see cref="CultureInfo.CurrentCulture"/>
+        /// A date formatted by using a format-string and <see cref="CultureInfo.InvariantCulture"/>
         /// </summary>
         /// <param name="date">a date</param>
         /// <param name="format">a format pattern</param>
-        public DateAsText(DateTime date, IText format) : this(new Live<DateTime>(date), format, CultureInfo.CurrentCulture)
+        public DateAsText(IScalar<DateTime> date, string format) : this(date, new LiveText(format), CultureInfo.InvariantCulture)
         { }
 
         /// <summary>
-        /// A date formatted by using a format-string and <see cref="CultureInfo.CurrentCulture"/>
+        /// A date formatted by using a format-string and <see cref="CultureInfo.InvariantCulture"/>
         /// </summary>
         /// <param name="date">a date</param>
         /// <param name="format">a format pattern</param>
-        public DateAsText(IScalar<DateTime> date, IText format) : this(date, format, CultureInfo.CurrentCulture)
+        public DateAsText(DateTime date, IText format) : this(new Live<DateTime>(date), format, CultureInfo.InvariantCulture)
+        { }
+
+        /// <summary>
+        /// A date formatted by using a format-string and <see cref="CultureInfo.InvariantCulture"/>
+        /// </summary>
+        /// <param name="date">a date</param>
+        /// <param name="format">a format pattern</param>
+        public DateAsText(IScalar<DateTime> date, IText format) : this(date, format, CultureInfo.InvariantCulture)
         { }
 
         /// <summary>
@@ -106,7 +123,7 @@ namespace Yaapii.Atoms.Time
         /// <returns></returns>
         public string AsString()
         {
-            return formatted.Value();
+            return this.formatted.Value();
         }
 
         /// <summary>
@@ -116,7 +133,7 @@ namespace Yaapii.Atoms.Time
         /// <returns></returns>
         public bool Equals(IText other)
         {
-            return formatted.Value().Equals(other.AsString());
+            return this.formatted.Value().Equals(other.AsString());
         }
     }
 }

--- a/tests/Yaapii.Atoms.Tests/Time/DateAsTextTest.cs
+++ b/tests/Yaapii.Atoms.Tests/Time/DateAsTextTest.cs
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright(c) 2023 ICARUS Consulting GmbH
+// Copyright(c) 2024 ICARUS Consulting GmbH
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 using System;
+using System.Globalization;
 using Xunit;
 
 namespace Yaapii.Atoms.Time.Tests
@@ -44,6 +45,31 @@ namespace Yaapii.Atoms.Time.Tests
                 new DateAsText(
                     new DateTime(2017, 12, 13, 14, 15, 16, 17, DateTimeKind.Local),
                     "yyyy-MM-dd HH:mm:ss").AsString() == "2017-12-13 14:15:16");
+        }
+
+        [Fact]
+        public void FormatsWithInvariantCulture()
+        {
+            Assert.Equal(
+                "12/13/2017 14:15:16",
+                new DateAsText(
+                    new DateTime(2017, 12, 13, 14, 15, 16, 17, DateTimeKind.Unspecified),
+                    ""
+                ).AsString()
+            );
+        }
+
+        [Fact]
+        public void FormatsWithCustomCulture()
+        {
+            Assert.Equal(
+                "13.12.2017 14:15:16",
+                new DateAsText(
+                    new DateTime(2017, 12, 13, 14, 15, 16, 17, DateTimeKind.Unspecified),
+                    "",
+                    CultureInfo.GetCultureInfo("de-de")
+                ).AsString()
+            );
         }
     }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
<!-- Describe the current behavior or link to a open issue -->
See #563

### What is the new behavior?
<!-- Describe the new behavior -->
closes #563

### Does this PR introduce a breaking change? (check one with "x")
- [x] Yes
- [ ] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications
DateAsText previously used ```CultureInfo.CurrentCulture``` by default, now it uses ```CultureInfo.InvariantCulture``` instead, so the formatting of the resulting string is different if no other format provider was given.
If formatting for the current culture is needed, ```CultureInfo.CurrentCulture``` now needs to be explicitly specified, for example:
```csharp
new DateAsText(date, CultureInfo.CurrentCulture);
new DateAsText(date, format, CultureInfo.CurrentCulture);
```

###  Other information